### PR TITLE
Update to Rust edition 2018.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-edition = "2018"
-
 [package]
 name = "sic"
 version = "0.7.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,7 @@
+cargo-features = ["edition"]
+
 [package]
+edition = "2018"
 name = "sic"
 version = "0.7.2"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+edition = "2018"
+
 [package]
 name = "sic"
 version = "0.7.2"

--- a/src/conversion/mod.rs
+++ b/src/conversion/mod.rs
@@ -1,4 +1,4 @@
-extern crate image;
+use image;
 
 use std::fs::File;
 use std::path::Path;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-
-
 use image;
 
 #[macro_use]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-extern crate arrayvec;
-extern crate clap;
-extern crate image;
-extern crate pest;
+
+
+use image;
+
 #[macro_use]
 extern crate pest_derive;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-#![feature(rust_2018_preview)]
-#![feature(extern_prelude)]
-
 extern crate arrayvec;
 extern crate clap;
 extern crate image;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![feature(rust_2018_preview)]
 #![feature(extern_prelude)]
 
 extern crate arrayvec;

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -2,8 +2,8 @@ use arrayvec::ArrayVec;
 use image::DynamicImage;
 use pest::Parser;
 
-use operations::operations::apply_operations_on_image;
-use operations::parse::parse_image_operations;
+use crate::operations::operations::apply_operations_on_image;
+use crate::operations::parse::parse_image_operations;
 
 #[cfg(test)]
 mod test_setup;
@@ -51,7 +51,7 @@ pub fn parse_and_apply_script(image: DynamicImage, script: &str) -> Result<Dynam
 #[cfg(test)]
 mod tests {
     use super::*;
-    use operations::test_setup::*;
+    use crate::operations::test_setup::*;
 
     #[test]
     fn test_too_many_args() {

--- a/src/operations/operations.rs
+++ b/src/operations/operations.rs
@@ -62,8 +62,8 @@ pub fn apply_operations_on_image(
 mod tests {
     use super::*;
     use arrayvec::ArrayVec;
-    use image::GenericImage;
     use crate::operations::test_setup::*;
+    use image::GenericImage;
 
     #[test]
     fn test_blur() {

--- a/src/operations/operations.rs
+++ b/src/operations/operations.rs
@@ -63,7 +63,7 @@ mod tests {
     use super::*;
     use arrayvec::ArrayVec;
     use image::GenericImage;
-    use operations::test_setup::*;
+    use crate::operations::test_setup::*;
 
     #[test]
     fn test_blur() {

--- a/src/operations/parse.rs
+++ b/src/operations/parse.rs
@@ -8,7 +8,7 @@ use super::{Operation, Operations, Rule};
 // It returns an error (Err) in case of any parse failure.
 // The error currently contains a String, but this will need to be reworked to proper error types.
 // The function is supposed to never panic.
-pub fn parse_image_operations(pairs: Pairs<Rule>) -> Result<Operations, String> {
+pub fn parse_image_operations(pairs: Pairs<'_, Rule>) -> Result<Operations, String> {
     pairs
         .map(|pair| match pair.as_rule() {
             Rule::blur => parse_unop_f32(pair).map(|u| Operation::Blur(u)),
@@ -37,7 +37,7 @@ pub fn parse_image_operations(pairs: Pairs<Rule>) -> Result<Operations, String> 
 
 // The code below, should work for parsing the 9 elements of a 3x3 fp32 triplet structure, but
 // let's be honest; this code can't be called beautiful. This should be refactored.
-fn parse_triplet3x_f32(pair: Pair<Rule>) -> Result<ArrayVec<[f32; 9]>, String> {
+fn parse_triplet3x_f32(pair: Pair<'_, Rule>) -> Result<ArrayVec<[f32; 9]>, String> {
     const SIZE: usize = 9;
 
     let mut inner = pair.into_inner();
@@ -82,7 +82,7 @@ fn parse_triplet3x_f32(pair: Pair<Rule>) -> Result<ArrayVec<[f32; 9]>, String> {
 }
 
 // generalizing this to T1/T2 would be nice, but gave me a lot of headaches. Using this for now.
-fn parse_unop_f32(pair: Pair<Rule>) -> Result<f32, String> {
+fn parse_unop_f32(pair: Pair<'_, Rule>) -> Result<f32, String> {
     let mut inner = pair.into_inner();
 
     inner
@@ -92,7 +92,7 @@ fn parse_unop_f32(pair: Pair<Rule>) -> Result<f32, String> {
         .and_then(|it: &str| it.parse::<f32>().map_err(|err| err.to_string()))
 }
 
-fn parse_unop_i32(pair: Pair<Rule>) -> Result<i32, String> {
+fn parse_unop_i32(pair: Pair<'_, Rule>) -> Result<i32, String> {
     pair.into_inner()
         .next()
         .ok_or_else(|| format!("Unable to parse UnOp::i32, Expected 2 arguments."))
@@ -100,7 +100,7 @@ fn parse_unop_i32(pair: Pair<Rule>) -> Result<i32, String> {
         .and_then(|it: &str| it.parse::<i32>().map_err(|err| err.to_string()))
 }
 
-fn parse_binop_u32(pair: Pair<Rule>) -> (Result<u32, String>, Result<u32, String>) {
+fn parse_binop_u32(pair: Pair<'_, Rule>) -> (Result<u32, String>, Result<u32, String>) {
     let mut inner = pair.into_inner();
 
     let x_text = inner
@@ -120,7 +120,7 @@ fn parse_binop_u32(pair: Pair<Rule>) -> (Result<u32, String>, Result<u32, String
     (x, y)
 }
 
-fn parse_binop_f32_i32(pair: Pair<Rule>) -> (Result<f32, String>, Result<i32, String>) {
+fn parse_binop_f32_i32(pair: Pair<'_, Rule>) -> (Result<f32, String>, Result<i32, String>) {
     let mut inner = pair.into_inner();
 
     let x_text = inner

--- a/src/operations/parse.rs
+++ b/src/operations/parse.rs
@@ -143,7 +143,7 @@ fn parse_binop_f32_i32(pair: Pair<Rule>) -> (Result<f32, String>, Result<i32, St
 #[cfg(test)]
 mod tests {
     use super::*;
-    use operations::SICParser;
+    use crate::operations::SICParser;
     use pest::Parser;
 
     #[test]


### PR DESCRIPTION
Update to Rust edition 2018 with `cargo fix`.

[edition guide: transition](https://rust-lang-nursery.github.io/edition-guide/editions/transitioning-your-code-to-a-new-edition.html#fix-edition-compatibility-warnings)