### PR TITLE
Remove cargo feature: edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["edition"]
-
 [package]
 edition = "2018"
 name = "sic"


### PR DESCRIPTION
This PR removes the cargo edition feature specification. 
It is now marked as stable by Cargo, so it can be removed from the Cargo.toml