### PR TITLE
Fix bug where output was always required to be constructed in the Config.

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -21,8 +21,8 @@ pub struct Config {
 
     pub encoding_settings: FormatEncodingSettings,
 
-    // output path
-    pub output: String,
+    // output path, err as String
+    pub output: Option<String>,
 }
 
 #[derive(Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ pub struct Config {
 
     pub encoding_settings: FormatEncodingSettings,
 
-    // output path, err as String
+    // output path
     pub output: Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,10 +119,7 @@ fn main() -> Result<(), String> {
             pnm_settings: PNMEncodingSettings::new(matches.is_present("pnm_encoding_ascii")),
         },
 
-        output: matches
-            .value_of("output_file")
-            .expect("An OUTPUT was expected, but none was given.")
-            .into(),
+        output: matches.value_of("output_file").map(|v| v.into()),
     };
 
     let license_display_processor = LicenseDisplayProcessor::new();

--- a/src/operations/transformations.rs
+++ b/src/operations/transformations.rs
@@ -54,9 +54,9 @@ pub fn apply_operations_on_image(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::operations::mod_test_includes::*;
     use arrayvec::ArrayVec;
     use image::GenericImageView;
-    use crate::operations::mod_test_includes::*;
 
     #[test]
     fn test_blur() {

--- a/src/processor/encoding_format.rs
+++ b/src/processor/encoding_format.rs
@@ -11,13 +11,20 @@ impl EncodingFormatDecider {
         EncodingFormatDecider {}
     }
 
-    fn get_output_extension(config: &Config) -> Option<String> {
-        let path = &Path::new(&config.output);
-        let extension = path.extension();
+    // return: Ok: valid extension, err: invalid i.e. no extension or no valid output path
+    fn get_output_extension(config: &Config) -> Result<String, String> {
+        match &config.output {
+            Some(v) => {
+                let path = &Path::new(v);
+                let extension = path.extension();
 
-        extension
-            .and_then(|out| out.to_str())
-            .map(|v| v.to_lowercase())
+                extension
+                    .and_then(|out| out.to_str())
+                    .ok_or_else(|| "No extension was found".into())
+                    .map(|v| v.to_lowercase())
+            }
+            None => Err("No valid output path found (type: efd/ext)".into()),
+        }
     }
 
     fn sample_encoding(config: &Config) -> image::pnm::SampleEncoding {
@@ -33,7 +40,7 @@ impl EncodingFormatDecider {
         if let Some(v) = &config.forced_output_format {
             Ok(v.to_lowercase())
         } else {
-            EncodingFormatDecider::get_output_extension(config).ok_or_else(|| "Unable to determine a supported image format type from the image's file extension.".to_string())
+            EncodingFormatDecider::get_output_extension(config)
         }
     }
 
@@ -152,11 +159,9 @@ mod tests {
                 pnm_settings: PNMEncodingSettings::new(pnm_ascii),
             },
 
-            output: String::from(
-                setup_output_path(&format!("{}.{}", output, ext))
-                    .to_str()
-                    .expect("Path given is no good!"),
-            ),
+            output: setup_output_path(&format!("{}.{}", output, ext))
+                .to_str()
+                .map(|v| v.into()),
         }
     }
 
@@ -313,11 +318,9 @@ mod tests {
                 pnm_settings: PNMEncodingSettings::new(false),
             },
 
-            output: String::from(
-                setup_output_path("encoding_processing_jpeg_quality_valid.jpg")
-                    .to_str()
-                    .expect("Path given is no good!"),
-            ),
+            output: setup_output_path("encoding_processing_jpeg_quality_valid.jpg")
+                .to_str()
+                .map(|v| v.into()),
         };
 
         let conversion_processor = EncodingFormatDecider::new();
@@ -343,11 +346,9 @@ mod tests {
                 pnm_settings: PNMEncodingSettings::new(false),
             },
 
-            output: String::from(
-                setup_output_path("encoding_processing_invalid.😉")
-                    .to_str()
-                    .expect("Path given is no good!"),
-            ),
+            output: setup_output_path("encoding_processing_invalid.😉")
+                .to_str()
+                .map(|v| v.into()),
         };
 
         let conversion_processor = EncodingFormatDecider::new();
@@ -371,11 +372,9 @@ mod tests {
                 pnm_settings: PNMEncodingSettings::new(false),
             },
 
-            output: String::from(
-                setup_output_path("encoding_processing_invalid.")
-                    .to_str()
-                    .expect("Path given is no good!"),
-            ),
+            output: setup_output_path("encoding_processing_invalid.")
+                .to_str()
+                .map(|v| v.into()),
         };
 
         let conversion_processor = EncodingFormatDecider::new();
@@ -399,11 +398,9 @@ mod tests {
                 pnm_settings: PNMEncodingSettings::new(false),
             },
 
-            output: String::from(
-                setup_output_path("encoding_processing_invalid.jpg")
-                    .to_str()
-                    .expect("Path given is no good!"),
-            ),
+            output: setup_output_path("encoding_processing_invalid.jpg")
+                .to_str()
+                .map(|v| v.into()),
         };
 
         let conversion_processor = EncodingFormatDecider::new();
@@ -427,11 +424,9 @@ mod tests {
                 pnm_settings: PNMEncodingSettings::new(false),
             },
 
-            output: String::from(
-                setup_output_path("encoding_processing_invalid")
-                    .to_str()
-                    .expect("Path given is no good!"),
-            ),
+            output: setup_output_path("encoding_processing_invalid")
+                .to_str()
+                .map(|v| v.into()),
         };
 
         let conversion_processor = EncodingFormatDecider::new();


### PR DESCRIPTION
Some clap options/flags do not require an output file to be given as argument.
By including the output path directly in the config, an output path was always required.
This commit makes Config.output an Option, so that one can be provided
if required, but also None can be given.