### PR TITLE
Move to Rust stable release channel from nightly.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,12 @@
 language: rust
 rust:
+  - stable
   - nightly
 cache: cargo
 os:
   - linux
   - windows
+matrix:
+  allow_failures:
+    - rust: nightly
+  fast_finish: true

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ With [cargo](https://crates.io/crates/sic) install: `cargo install --force sic`
 Pre build binary: see [releases](https://github.com/foresterre/sic/releases)
 
 From the source of this repo:
-- Setup rust and cargo with (for example) [rustup](https://rustup.rs/), a `nightly` version is required.
+- Setup rust and cargo with (for example) [rustup](https://rustup.rs/) <br> 
+  _Rust version >= 1.31 with 'Rust edition 2018' is required._
 - Clone this repo: `git clone https://github.com/foresterre/sic.git`
 - Switch to this repo: `cd sic`
 - Build a release: `cargo build --release`

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -2,7 +2,7 @@ Merge all PR's to the `master` branch, then:
 
 ### Verify
 
-0. Verify that each PR has run `cargo fmt`.
+0. Verify that each PR has run `cargo +nightly fmt`.
 1. Does `cargo test` succeed?
 2. Does `cargo run -- resources/bwlines.png target/out.jpg --script "blur 10; flipv; resize 10 10;"` complete
     successfully and produce a 10x10 blurred and flipped vertically JPEG image?

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,8 +59,9 @@ impl JPEGEncodingSettings {
         };
 
         fn within_range(v: u8) -> Result<JPEGEncodingSettings, String> {
-            const ALLOWED_RANGE: std::ops::RangeInclusive<u8> = 1..=100;
-            if ALLOWED_RANGE.contains(&v) {
+            // upper bound is exclusive with .. syntax.
+            const ALLOWED_RANGE: std::ops::Range<u8> = 1..101;
+            if v >= ALLOWED_RANGE.start && v <= ALLOWED_RANGE.end {
                 let res = JPEGEncodingSettings { quality: v };
 
                 Ok(res)

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,9 +59,11 @@ impl JPEGEncodingSettings {
         };
 
         fn within_range(v: u8) -> Result<JPEGEncodingSettings, String> {
-            // upper bound is exclusive with .. syntax.
+            // Upper bound is exclusive with .. syntax.
+            // When the `range_contains` feature will be stabilised Range.contains(&v)
+            // should be used instead.
             const ALLOWED_RANGE: std::ops::Range<u8> = 1..101;
-            if v >= ALLOWED_RANGE.start && v <= ALLOWED_RANGE.end {
+            if v >= ALLOWED_RANGE.start && v < ALLOWED_RANGE.end {
                 let res = JPEGEncodingSettings { quality: v };
 
                 Ok(res)
@@ -83,5 +85,34 @@ pub struct PNMEncodingSettings {
 impl PNMEncodingSettings {
     pub fn new(ascii: bool) -> PNMEncodingSettings {
         PNMEncodingSettings { ascii }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jpeg_in_quality_range_lower_bound_inside() {
+        let value: &str = "1";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_ok())
+    }
+
+    #[test]
+    fn jpeg_in_quality_range_lower_bound_outside() {
+        let value: &str = "0";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_err())
+    }
+
+    #[test]
+    fn jpeg_in_quality_range_upper_bound_inside() {
+        let value: &str = "100";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_ok())
+    }
+
+    #[test]
+    fn jpeg_in_quality_range_upper_bound_outside() {
+        let value: &str = "101";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_err())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(range_contains)]
-
 use std::path::Path;
 
 use clap::{App, Arg, ArgMatches};


### PR DESCRIPTION
This PR makes it possible to use the Rust stable channel by removing the `range_contains` feature, which is only available on the Rust nightly release channel.

A Rust version 1.31 compiler with Rust edition 2018 is required as of now.
This is not tested in the TravisCI as of this PR. Perhaps it should?
Or should just the latest stable version be required?



--- 

Issue: #79 