### PR TITLE
Publish stable compatible version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -406,7 +406,7 @@ dependencies = [
 
 [[package]]
 name = "sic"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2018"
 name = "sic"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 description = "`sic` stands for simple image converter and is a partial front-end for the `image` crate."
 license = "MIT"

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -72,7 +72,7 @@ we can move on to the next step.
 - [ ] Add Windows and Linux (Ubuntu compiled) binaries to the release
     - compile with `cargo build --release`
 
-
+---
 
 [Release steps](https://github.com/foresterre/sic/blob/master/RELEASE_STEPS.md)
 

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -52,6 +52,8 @@ Blocking:
 
 Same as above.
 
+- [ ] Completed!
+
 **Merge Release PR**
 
 If no blocking issues are detected and this checklist is complete,

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -1,38 +1,81 @@
-Merge all PR's to the `master` branch, then:
+<!-- Merge all PR's to the `master` branch, then: -->
 
-### Verify
+<!-- ### Release
+Optional:
 
-0. Verify that each PR has run `cargo +nightly fmt`.
-1. Does `cargo test` succeed?
-2. Does `cargo run -- resources/bwlines.png target/out.jpg --script "blur 10; flipv; resize 10 10;"` complete
-    successfully and produce a 10x10 blurred and flipped vertically JPEG image?
-3. Do all CI runs complete successfully?
+A description about what is included in this update, a thank you or something
+else which is noteworthy :).
+-->
+
+### Changes from `current version` to `new version`:
+- ...
+- ...
+- ...
+
+---
+
+### Problems encountered & their resolutions
+
+Blocking:
+- [ ] ...
+- [ ] ...
+- [ ] ...
+
+---
+
+### Release checklist
+
+**Create Release PR**
+
+- [ ] Included this checklist. Already a step complete! :wink:
+
+**Verify**
+
+- [ ] Verify that each PR has run `cargo fmt`.
+- [ ] Does `cargo test` succeed?
+- [ ] Verify image output of images produced with `cargo test --features output-test-images`.
+- [ ] Do all CI runs complete successfully?
 
 
-### Update version number
+**Update version number**
 
-4. Define update version number [as described here](https://doc.rust-lang.org/cargo/reference/publishing.html#publishing-a-new-version-of-an-existing-crate)
-5. Update the version number in `Cargo.toml`
-6. Update the version number in `src/main.rs` at the `Clap App .about()/1`
-
-### Update the dependency licenses to be included in the binary as per their licenses.
-
-7. Run `cargo run --example update_dep_licenses` to update the licenses of dependencies, which will be included in
-    a binary build.
-
-### Publish & Upload
-
-8. Run `cargo package` and check the resulting `.crate`
-9. Run `cargo publish` and verify the result
+- [ ] Define update version number [as described here](https://doc.rust-lang.org/cargo/reference/publishing.html#publishing-a-new-version-of-an-existing-crate).
+- [ ] Update the version number in `Cargo.toml`.
+- The Clap App version number in `src/main.rs` will be equal to the version number in `Cargo.toml`.
 
 
-### Release, Tag & Binaries
+**Update the dependency licenses to be included in the binary as per their licenses.**
 
-10. Create a release with a version tag on [the github release page](https://github.com/foresterre/sic/releases)
+- [ ] Run `cargo run --example update_dep_licenses` to update the licenses of dependencies, which will be included in a binary build.
+
+**Verify again**
+
+Same as above.
+
+**Merge Release PR**
+
+If no blocking issues are detected and this checklist is complete,
+we can move on to the next step.
+
+**Publish & Upload**
+
+- [ ] Run `cargo package` and check the resulting `.crate`
+- [ ] Run `cargo publish` and verify the result
+
+**Release, Tag & Binaries**
+
+- [ ] Create a release with a version tag on [the github release page](https://github.com/foresterre/sic/releases)
     - tags are equal to crate version number e.g. `0.5.1`
     - release title is `sic-<version>` e.g. `sic-0.5.1`
 
 
-11. Add Windows and Linux (Ubuntu compiled) binaries to the release
+- [ ] Add Windows and Linux (Ubuntu compiled) binaries to the release
     - compile with `cargo build --release`
 
+
+
+[Release steps](https://github.com/foresterre/sic/blob/master/RELEASE_STEPS.md)
+
+---
+
+PR: #<PR NUMBER>

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -31,7 +31,7 @@ Blocking:
 
 **Verify**
 
-- [ ] Verify that each PR has run `cargo fmt`.
+- [ ] Verify formatting with `cargo +nightly fmt`.
 - [ ] Does `cargo test` succeed?
 - [ ] Verify image output of images produced with `cargo test --features output-test-images`.
 - [ ] Do all CI runs complete successfully?

--- a/RELEASE_STEPS.md
+++ b/RELEASE_STEPS.md
@@ -8,18 +8,18 @@ else which is noteworthy :).
 -->
 
 ### Changes from `current version` to `new version`:
-- ...
-- ...
-- ...
+- ... (issue: #X, PR: #Y)
+- ... (issue: #X, PR: #Y)
+- ... (issue: #X, PR: #Y)
 
 ---
 
 ### Problems encountered & their resolutions
 
 Blocking:
-- [ ] ...
-- [ ] ...
-- [ ] ...
+- [ ] ... (issue: #X, PR: #Y)
+- [ ] ... (issue: #X, PR: #Y)
+- [ ] ... (issue: #X, PR: #Y)
 
 ---
 
@@ -44,7 +44,7 @@ Blocking:
 - The Clap App version number in `src/main.rs` will be equal to the version number in `Cargo.toml`.
 
 
-**Update the dependency licenses to be included in the binary as per their licenses.**
+**Update the dependency licenses to be included in the binary as per their licenses**
 
 - [ ] Run `cargo run --example update_dep_licenses` to update the licenses of dependencies, which will be included in a binary build.
 


### PR DESCRIPTION
Rerelease the 0.8.0 version (but with a new version number) now it is compatible with a stable compiler release.

- Should the version number be 0.8.1 or 0.9.0
- In case of 0.9.0, need to shift all planned features by one.

decided: 0.8.1 since no breaking changes are made for a user

-- 

issue: #82 

