### PR TITLE
image operation: crop

### DIFF
--- a/src/operations/grammar.pest
+++ b/src/operations/grammar.pest
@@ -15,6 +15,7 @@ f3x3_args_no_sep = _{ triplet_fp3 ~ whitespace ~ triplet_fp3  ~ whitespace ~ tri
 blur = ${ ^"blur" ~ whitespace ~ uint}
 brighten = ${ ^"brighten" ~ whitespace ~ int }
 contrast = ${ ^"contrast" ~ whitespace ~ fp }
+crop = ${ ^"crop" ~ whitespace ~ uint ~ whitespace ~ uint ~ whitespace ~ uint ~ whitespace ~ uint }
 filter3x3 = ${ ^"filter3x3" ~ whitespace ~ (f3x3_args_sep | f3x3_args_no_sep) }
 flip_horizontal = { ^"fliph" }
 flip_vertical = { ^"flipv"  }
@@ -30,6 +31,6 @@ unsharpen = ${ ^"unsharpen" ~ whitespace ~ fp ~ whitespace ~ int }
 
 operation_sequence = _{ (operation ~ whitespace? ~ sep? ~ whitespace?)+ }
 
-operation = _{ blur | brighten | contrast | filter3x3 | flip_horizontal | flip_vertical | grayscale | huerotate | invert | resize | rotate90 | rotate180 | rotate270 | unsharpen }
+operation = _{ blur | brighten | contrast | crop | filter3x3 | flip_horizontal | flip_vertical | grayscale | huerotate | invert | resize | rotate90 | rotate180 | rotate270 | unsharpen }
 
 main = _{ SOI ~ operation_sequence ~ EOI }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -22,6 +22,7 @@ pub enum Operation {
     Blur(f32),
     Brighten(i32),
     Contrast(f32),
+    Crop(u32, u32, u32, u32),
     Filter3x3(ArrayVec<[f32; 9]>),
     FlipHorizontal,
     FlipVertical,

--- a/src/operations/parse.rs
+++ b/src/operations/parse.rs
@@ -210,6 +210,16 @@ mod tests {
     }
 
     #[test]
+    fn test_crop_in_order_parse_correct() {
+        let pairs = SICParser::parse(Rule::main, "crop 1 2 3 4;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+        assert_eq!(
+            Ok(vec![Operation::Crop(1, 2, 3, 4)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
     fn test_crop_ones_parse_correct() {
         // Here we don't check that rX > lX and rY > lY
         // We only check that the values are uint and in range (u32)

--- a/src/operations/parse.rs
+++ b/src/operations/parse.rs
@@ -15,6 +15,7 @@ pub fn parse_image_operations(pairs: Pairs<'_, Rule>) -> Result<Vec<Operation>, 
             Rule::blur => parse_unop_f32(pair).map(Operation::Blur),
             Rule::brighten => parse_unop_i32(pair).map(Operation::Brighten),
             Rule::contrast => parse_unop_f32(pair).map(Operation::Contrast),
+            Rule::crop => parse_4_tuple_crop_result(parse_quad_op_u32(pair)),
             Rule::filter3x3 => parse_triplet3x_f32(pair).map(Operation::Filter3x3),
             Rule::flip_horizontal => Ok(Operation::FlipHorizontal),
             Rule::flip_vertical => Ok(Operation::FlipVertical),
@@ -96,6 +97,56 @@ fn parse_binop_f32_i32(pair: Pair<'_, Rule>) -> (Result<f32, String>, Result<i32
     (x, y)
 }
 
+type QuadOpU32 = (
+    Result<u32, String>,
+    Result<u32, String>,
+    Result<u32, String>,
+    Result<u32, String>,
+);
+
+// simplify tuple with individual error messages
+fn parse_4_tuple_crop_result(tuple: QuadOpU32) -> Result<Operation, String> {
+    let (xl, yl, xr, yr) = tuple;
+    xl.and_then(|lxu| {
+        yl.and_then(|lyu| xr.and_then(|rxu| yr.map(|ryu| Operation::Crop(lxu, lyu, rxu, ryu))))
+    })
+}
+
+fn parse_quad_op_u32(pair: Pair<'_, Rule>) -> QuadOpU32 {
+    let mut inner = pair.into_inner();
+
+    let left_top_corner_x = inner
+        .next()
+        .ok_or_else(|| "Unable to parse QuadOp::<u32, u32, u32, u32> (n=1)".to_string())
+        .map(|val| val.as_str())
+        .and_then(|it: &str| it.parse::<u32>().map_err(|err| err.to_string()));
+
+    let left_top_corner_y = inner
+        .next()
+        .ok_or_else(|| "Unable to parse QuadOp::<u32, u32, u32, u32> (n=2)".to_string())
+        .map(|val| val.as_str())
+        .and_then(|it: &str| it.parse::<u32>().map_err(|err| err.to_string()));
+
+    let right_bottom_corner_x = inner
+        .next()
+        .ok_or_else(|| "Unable to parse QuadOp::<u32, u32, u32, u32> (n=3)".to_string())
+        .map(|val| val.as_str())
+        .and_then(|it: &str| it.parse::<u32>().map_err(|err| err.to_string()));
+
+    let right_bottom_corner_y = inner
+        .next()
+        .ok_or_else(|| "Unable to parse QuadOp::<u32, u32, u32, u32> (n=3)".to_string())
+        .map(|val| val.as_str())
+        .and_then(|it: &str| it.parse::<u32>().map_err(|err| err.to_string()));
+
+    (
+        left_top_corner_x,
+        left_top_corner_y,
+        right_bottom_corner_x,
+        right_bottom_corner_y,
+    )
+}
+
 // The code below, should work for parsing the 9 elements of a 3x3 fp32 triplet structure, but
 // let's be honest; this code can't be called beautiful. This should be refactored.
 fn parse_triplet3x_f32(pair: Pair<'_, Rule>) -> Result<ArrayVec<[f32; 9]>, String> {
@@ -154,6 +205,89 @@ mod tests {
             .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
         assert_eq!(
             Ok(vec![Operation::Blur(15.0)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_crop_ones_parse_correct() {
+        // Here we don't check that rX > lX and rY > lY
+        // We only check that the values are uint and in range (u32)
+        // lX = upper left X coordinate
+        // lY = upper left Y coordinate
+        // rX = bottom right X coordinate
+        // rY = bottom right Y coordinate
+
+        let pairs = SICParser::parse(Rule::main, "crop 1 1 1 1;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+        assert_eq!(
+            Ok(vec![Operation::Crop(1, 1, 1, 1)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_crop_zeros_parse_correct() {
+        let pairs = SICParser::parse(Rule::main, "crop 0 0 0 0;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+        assert_eq!(
+            Ok(vec![Operation::Crop(0, 0, 0, 0)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_crop_args_negative_parse_err() {
+        SICParser::parse(Rule::main, "crop -1 -1 -1 -1;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_crop_arg_negative_p1_parse_err() {
+        SICParser::parse(Rule::main, "crop -1 0 0 0;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_crop_arg_negative_p2_parse_err() {
+        SICParser::parse(Rule::main, "crop 0 -1 0 0;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_crop_arg_negative_p3_parse_err() {
+        SICParser::parse(Rule::main, "crop 0 0 -1 0;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_crop_arg_negative_p4_parse_err() {
+        SICParser::parse(Rule::main, "crop 0 0 0 -1;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+    }
+
+    #[test]
+    fn test_crop_arg_to_big_p4_parse_err() {
+        // 4294967296 == std::u32::MAX + 1
+        let pairs = SICParser::parse(Rule::main, "crop 0 0 0 4294967296")
+            .unwrap_or_else(|_| panic!("Unable to parse sic image operations script."));
+
+        assert!(parse_image_operations(pairs).is_err())
+    }
+
+    #[test]
+    fn test_crop_arg_just_in_range_p4_parse_ok() {
+        // 4294967296 == std::u32::MAX
+        let pairs = SICParser::parse(Rule::main, "crop 0 0 0 4294967295")
+            .unwrap_or_else(|_| panic!("Unable to parse sic image operations script."));
+
+        assert_eq!(
+            Ok(vec![Operation::Crop(0, 0, 0, std::u32::MAX)]),
             parse_image_operations(pairs)
         );
     }

--- a/src/operations/transformations.rs
+++ b/src/operations/transformations.rs
@@ -14,19 +14,28 @@ impl ApplyOperation<Operation, DynamicImage, String> for DynamicImage {
             Operation::Brighten(amount) => Ok(self.brighten(amount)),
             Operation::Contrast(c) => Ok(self.adjust_contrast(c)),
             Operation::Crop(lx, ly, rx, ry) => {
-
                 // TODO: here
                 // TODO: check oerder of Operation::Crop(1,2,3,4)
 
-                if rx <= lx || ry <= ly {
-                    return Err(format!("Operation crop: is {}<{} (top selection) and {}<{} (bottom selection)?", lx, rx, ly, ry));
-                }
-                else {
+                if rx > lx || ry > ly {
+                    return Err(format!(
+                        "Operation crop: is {}<{} (top selection) and {}<{} (bottom selection)?",
+                        lx, rx, ly, ry
+                    ));
+                } else {
                     let lxi = lx as i32;
                     let rxi = rx as i32;
                     let lyi = ly as i32;
                     let ryi = ry as i32;
-                    println!("LEFT: {}-{}={}, and RIGHT: {}-{}={}", lxi, rxi, rxi-lxi, lyi, ryi, ryi-lyi);
+                    println!(
+                        "LEFT: {}-{}={}, and RIGHT: {}-{}={}",
+                        lxi,
+                        rxi,
+                        rxi - lxi,
+                        lyi,
+                        ryi,
+                        ryi - lyi
+                    );
                 }
 
                 let cropped = {
@@ -238,9 +247,15 @@ mod tests {
         assert_eq!(1, result_dim.1);
 
         assert_eq!(image::Rgba([0, 0, 0, 255]), result_img.get_pixel(0, 0));
-        assert_eq!(image::Rgba([255, 255, 255, 255]), result_img.get_pixel(1, 0));
+        assert_eq!(
+            image::Rgba([255, 255, 255, 255]),
+            result_img.get_pixel(1, 0)
+        );
 
-        output_test_image_for_manual_inspection(&result_img, "target/test_crop_ok_to_half_horizontal.bmp")
+        output_test_image_for_manual_inspection(
+            &result_img,
+            "target/test_crop_ok_to_half_horizontal.bmp",
+        )
     }
 
     #[test]

--- a/src/operations/transformations.rs
+++ b/src/operations/transformations.rs
@@ -13,6 +13,29 @@ impl ApplyOperation<Operation, DynamicImage, String> for DynamicImage {
             Operation::Blur(sigma) => Ok(self.blur(sigma)),
             Operation::Brighten(amount) => Ok(self.brighten(amount)),
             Operation::Contrast(c) => Ok(self.adjust_contrast(c)),
+            Operation::Crop(lx, ly, rx, ry) => {
+
+                // TODO: here
+                // TODO: check oerder of Operation::Crop(1,2,3,4)
+
+                if rx <= lx || ry <= ly {
+                    return Err(format!("Operation crop: is {}<{} (top selection) and {}<{} (bottom selection)?", lx, rx, ly, ry));
+                }
+                else {
+                    let lxi = lx as i32;
+                    let rxi = rx as i32;
+                    let lyi = ly as i32;
+                    let ryi = ry as i32;
+                    println!("LEFT: {}-{}={}, and RIGHT: {}-{}={}", lxi, rxi, rxi-lxi, lyi, ryi, ryi-lyi);
+                }
+
+                let cropped = {
+                    let mut buffer = self.clone();
+                    buffer.crop(lx, ly, rx - lx, ry - ly)
+                };
+
+                Ok(cropped)
+            }
             // We need to ensure here that Filter3x3's `it` (&[f32]) has length 9.
             // Otherwise it will panic, see: https://docs.rs/image/0.19.0/src/image/dynimage.rs.html#349
             // This check already happens within the `parse` module.
@@ -23,10 +46,13 @@ impl ApplyOperation<Operation, DynamicImage, String> for DynamicImage {
             Operation::HueRotate(degree) => Ok(self.huerotate(degree)),
             // TODO this is rather sub optimal with the double clone
             Operation::Invert => {
-                let img = &mut self.clone();
-                image::DynamicImage::invert(img);
-                let res = img.clone();
-                Ok(res)
+                let inverted = {
+                    let mut buffer = self.clone();
+                    buffer.invert();
+                    buffer
+                };
+
+                Ok(inverted)
             }
             Operation::Resize(new_x, new_y) => {
                 Ok(self.resize_exact(new_x, new_y, FilterType::Gaussian))
@@ -151,6 +177,105 @@ mod tests {
         assert_ne!(cmp.raw_pixels(), result_img.raw_pixels());
 
         output_test_image_for_manual_inspection(&result_img, "target/test_contrast_pos_15_9.png")
+    }
+
+    #[test]
+    fn test_crop_ok_no_change() {
+        let img: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+        let cmp: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+
+        let operation = Operation::Crop(0, 0, 2, 2);
+
+        let done = img.apply_operation(&operation);
+        assert!(done.is_ok());
+
+        let result_img = done.unwrap();
+
+        assert_eq!(cmp.raw_pixels(), result_img.raw_pixels());
+
+        output_test_image_for_manual_inspection(&result_img, "target/test_crop_no_change.bmp")
+    }
+
+    #[test]
+    fn test_crop_ok_to_one_pixel() {
+        let img: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+        let cmp: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+
+        let operation = Operation::Crop(0, 0, 1, 1);
+
+        let done = img.apply_operation(&operation);
+        assert!(done.is_ok());
+
+        let result_img = done.unwrap();
+
+        assert_ne!(cmp.raw_pixels(), result_img.raw_pixels());
+
+        let result_dim = result_img.dimensions();
+        assert_eq!(1, result_dim.0);
+        assert_eq!(1, result_dim.1);
+
+        assert_eq!(image::Rgba([0, 0, 0, 255]), result_img.get_pixel(0, 0));
+
+        output_test_image_for_manual_inspection(&result_img, "target/test_crop_ok_to_one_pixel.bmp")
+    }
+
+    #[test]
+    fn test_crop_ok_to_half_horizontal() {
+        let img: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+        let cmp: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+
+        let operation = Operation::Crop(0, 0, 2, 1);
+
+        let done = img.apply_operation(&operation);
+        assert!(done.is_ok());
+
+        let result_img = done.unwrap();
+
+        assert_ne!(cmp.raw_pixels(), result_img.raw_pixels());
+
+        let result_dim = result_img.dimensions();
+        assert_eq!(2, result_dim.0);
+        assert_eq!(1, result_dim.1);
+
+        assert_eq!(image::Rgba([0, 0, 0, 255]), result_img.get_pixel(0, 0));
+        assert_eq!(image::Rgba([255, 255, 255, 255]), result_img.get_pixel(1, 0));
+
+        output_test_image_for_manual_inspection(&result_img, "target/test_crop_ok_to_half_horizontal.bmp")
+    }
+
+    #[test]
+    fn test_crop_err_lx_larger_than_rx() {
+        let img: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+
+        // not rx >= lx
+        let operation = Operation::Crop(1, 0, 0, 0);
+
+        let done = img.apply_operation(&operation);
+        assert!(done.is_err());
+    }
+
+    #[test]
+    fn test_crop_err_ly_larger_than_ry() {
+        let img: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+
+        // not rx >= lx
+        let operation = Operation::Crop(0, 1, 0, 0);
+
+        let done = img.apply_operation(&operation);
+        assert!(done.is_err());
+    }
+
+    #[test]
+    fn test_crop___DEBUG__() {
+        let img: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
+
+        // not rx >= lx
+        let operation = Operation::Crop(0, 0, 1, 1);
+
+        let done = img.apply_operation(&operation);
+        assert!(done.is_ok());
+
+        output_test_image_for_manual_inspection(&done.unwrap(), "target/__debug__.bmp")
     }
 
     #[test]

--- a/src/operations/transformations.rs
+++ b/src/operations/transformations.rs
@@ -14,28 +14,12 @@ impl ApplyOperation<Operation, DynamicImage, String> for DynamicImage {
             Operation::Brighten(amount) => Ok(self.brighten(amount)),
             Operation::Contrast(c) => Ok(self.adjust_contrast(c)),
             Operation::Crop(lx, ly, rx, ry) => {
-                // TODO: here
-                // TODO: check oerder of Operation::Crop(1,2,3,4)
-
-                if rx > lx || ry > ly {
+                // verify that there is a positive bounding box selection
+                if (rx <= lx) || (ry <= ly) {
                     return Err(format!(
                         "Operation crop: is {}<{} (top selection) and {}<{} (bottom selection)?",
                         lx, rx, ly, ry
                     ));
-                } else {
-                    let lxi = lx as i32;
-                    let rxi = rx as i32;
-                    let lyi = ly as i32;
-                    let ryi = ry as i32;
-                    println!(
-                        "LEFT: {}-{}={}, and RIGHT: {}-{}={}",
-                        lxi,
-                        rxi,
-                        rxi - lxi,
-                        lyi,
-                        ryi,
-                        ryi - lyi
-                    );
                 }
 
                 let cropped = {
@@ -278,19 +262,6 @@ mod tests {
 
         let done = img.apply_operation(&operation);
         assert!(done.is_err());
-    }
-
-    #[test]
-    fn test_crop___DEBUG__() {
-        let img: DynamicImage = setup_test_image("resources/blackwhite_2x2.bmp");
-
-        // not rx >= lx
-        let operation = Operation::Crop(0, 0, 1, 1);
-
-        let done = img.apply_operation(&operation);
-        assert!(done.is_ok());
-
-        output_test_image_for_manual_inspection(&done.unwrap(), "target/__debug__.bmp")
     }
 
     #[test]


### PR DESCRIPTION
Syntax:
- `crop LX LY RX RY`

- LX is Left top corner X coordinate starting at 0
- LY is Left top corner Y coordinate starting at 0
- RX is Right bottom corner X coordinate 
- RY is Right bottom corner Y coordinate 

Invariants:
`RX > LX` and `RY > LY`
- if `>=` then 0 pixel axis' would be allowed.


Questions:
- What 2D coordinate system does the `image` crate use? / Where is x=0,y=0?
  > top left is (0,0)



--

issue: #64 