### PR TITLE
Require separators between operations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ PNM (PBM, PGM, PPM) by default uses binary encoding (PNM P4, P5 and P6 respectiv
 * In general: `sic --apply-operations "<operations>" <input> <output> ` (shorthand: `-A`) 
 * Example `sic input.png output.jpg --apply-operations "fliph; blur 10; resize 250 250"`
 
-The separator `;` within the image operation script is optional. It exists to provide clarity.  
+The separator `;` within the image operation script is required between multiple operations. 
+It exists to provide improved readability and clarity.  
 
 _Note: `resize` applies a gaussian sampling filter on resizing. This is currently the only sampling filter available.
 Additional sampling filters are planned for version 0.9.0_
@@ -111,7 +112,7 @@ contrast 1.35;
 filter3x3 10.0 9.0 8.0 | 7.5 6.5 5.5 | 4 3 2;
 filter3x3 10.0 9.0 8.0 7.5 6.5 5.5 4 3 2;
 filter3x3 10.0 9.0 8.0 7.5 6.5 5.5 4 3 2
-filter3x3 10.0 9.0 8.0 7.5 6.5 5.5 4 3 2 filter3x3 12.0 29.0 28 27.5 26 25.5 14 3 2
+filter3x3 10.0 9.0 8.0 7.5 6.5 5.5 4 3 2; filter3x3 12.0 29.0 28 27.5 26 25.5 14 3 2
 ```
 
 [E-FLIPH]. Flip horizontal operation example:

--- a/docs/cli_help_script.txt
+++ b/docs/cli_help_script.txt
@@ -37,10 +37,10 @@ table legend:
         or `filter3x3 1.0 0.9 | 0.8 | 0.7 0.6 0.5 | 0.4 0.3 0.2` are not.
 
 
-Operation separators (';') are optional.
+Operation separators (';') are required.
 
 Example 1: sic input.png output.png --apply-operations "resize 250 250; blur 5; huerotate -30"
-Example 2: sic input.png output.jpg --apply-operations "flipv resize 10 5 blur 100 grayscale"
+Example 2: sic input.png output.jpg --apply-operations "flipv; resize 10 5; blur 100; grayscale"
 Example 3: sic input.png output.jpg --apply-operations "filter3x3 1.0 0.9 0.8 | 0.7 0.6 0.5 | 0.4 0.3 0.2; flipv; invert"
 
 

--- a/src/operations/grammar.pest
+++ b/src/operations/grammar.pest
@@ -27,12 +27,26 @@ rotate180 = { ^"rotate180" }
 rotate270 = { ^"rotate270" }
 unsharpen = ${ ^"unsharpen" ~ WHITESPACE ~ fp ~ WHITESPACE ~ int }
 
-operation = _{ blur | brighten | contrast | crop | filter3x3 | flip_horizontal | flip_vertical | grayscale | huerotate | invert | resize | rotate90 | rotate180 | rotate270 | unsharpen }
+operation = _{
+    blur
+    | brighten
+    | contrast
+    | crop
+    | filter3x3
+    | flip_horizontal
+    | flip_vertical
+    | grayscale
+    | huerotate
+    | invert
+    | resize
+    | rotate90
+    | rotate180
+    | rotate270
+    | unsharpen
+}
 
-seq = _{
+sequence = _{
 	operation ~ ( (NEWLINE* ~ EOI) | (sep ~ NEWLINE+) | sep)
 }
 
-sequences = _{ seq* }
-
-main = _{ SOI ~ sequences ~ EOI }
+main = _{ SOI ~ sequence* ~ EOI }

--- a/src/operations/grammar.pest
+++ b/src/operations/grammar.pest
@@ -1,36 +1,38 @@
-whitespace = _{ (" " | "\t" | "\n" | "\r\n")+ }
+WHITESPACE = _{ " " }
 sep = _{ ";" }
 
 fp = @{ int ~ ("." ~ ASCII_DIGIT+)? }
 uint = @{ ASCII_DIGIT+ }
 int  = @{ "-"? ~ ASCII_DIGIT+ }
 
-triplet_sep = _{ whitespace ~ "|" ~ whitespace }
-triplet_fp3 = _{ fp ~ whitespace ~ fp ~ whitespace ~ fp }
+triplet_sep = _{ WHITESPACE ~ "|" ~ WHITESPACE }
+triplet_fp3 = _{ fp ~ WHITESPACE ~ fp ~ WHITESPACE ~ fp }
 
 f3x3_args_sep = _{ triplet_fp3 ~ triplet_sep ~ triplet_fp3 ~ triplet_sep ~ triplet_fp3 }
-f3x3_args_no_sep = _{ triplet_fp3 ~ whitespace ~ triplet_fp3  ~ whitespace ~ triplet_fp3 }
+f3x3_args_no_sep = _{ triplet_fp3 ~ WHITESPACE ~ triplet_fp3 ~ WHITESPACE ~ triplet_fp3 }
 
-
-blur = ${ ^"blur" ~ whitespace ~ uint}
-brighten = ${ ^"brighten" ~ whitespace ~ int }
-contrast = ${ ^"contrast" ~ whitespace ~ fp }
-crop = ${ ^"crop" ~ whitespace ~ uint ~ whitespace ~ uint ~ whitespace ~ uint ~ whitespace ~ uint }
-filter3x3 = ${ ^"filter3x3" ~ whitespace ~ (f3x3_args_sep | f3x3_args_no_sep) }
+blur = ${ ^"blur" ~ WHITESPACE ~ uint}
+brighten = ${ ^"brighten" ~ WHITESPACE ~ int }
+contrast = ${ ^"contrast" ~ WHITESPACE ~ fp }
+crop = ${ ^"crop" ~ WHITESPACE ~ uint ~ WHITESPACE ~ uint ~ WHITESPACE ~ uint ~ WHITESPACE ~ uint }
+filter3x3 = ${ ^"filter3x3" ~ WHITESPACE ~ (f3x3_args_sep | f3x3_args_no_sep) }
 flip_horizontal = { ^"fliph" }
 flip_vertical = { ^"flipv"  }
 grayscale = { ^"grayscale" }
-huerotate = ${ ^"huerotate" ~ whitespace ~ int }
+huerotate = ${ ^"huerotate" ~ WHITESPACE ~ int }
 invert = { ^"invert" }
-resize = ${ ^"resize" ~ whitespace ~ uint ~ whitespace ~ uint }
+resize = ${ ^"resize" ~ WHITESPACE ~ uint ~ WHITESPACE ~ uint }
 rotate90 = { ^"rotate90" }
 rotate180 = { ^"rotate180" }
 rotate270 = { ^"rotate270" }
-unsharpen = ${ ^"unsharpen" ~ whitespace ~ fp ~ whitespace ~ int }
-
-
-operation_sequence = _{ (operation ~ whitespace? ~ sep? ~ whitespace?)+ }
+unsharpen = ${ ^"unsharpen" ~ WHITESPACE ~ fp ~ WHITESPACE ~ int }
 
 operation = _{ blur | brighten | contrast | crop | filter3x3 | flip_horizontal | flip_vertical | grayscale | huerotate | invert | resize | rotate90 | rotate180 | rotate270 | unsharpen }
 
-main = _{ SOI ~ operation_sequence ~ EOI }
+seq = _{
+	operation ~ ( (NEWLINE* ~ EOI) | (sep ~ NEWLINE+) | sep)
+}
+
+sequences = _{ seq* }
+
+main = _{ SOI ~ sequences ~ EOI }

--- a/src/operations/mod.rs
+++ b/src/operations/mod.rs
@@ -9,8 +9,6 @@ mod mod_test_includes;
 mod parse;
 pub(crate) mod transformations;
 
-// ensure grammar refreshes on compile
-const _GRAMMAR: &str = include_str!("grammar.pest");
 const PARSER_RULE: Rule = Rule::main;
 
 #[derive(Parser)]

--- a/src/operations/parse.rs
+++ b/src/operations/parse.rs
@@ -200,6 +200,108 @@ mod tests {
     use pest::Parser;
 
     #[test]
+    fn test_parse_next_line_versions_fin_with_eoi() {
+        let pairs = SICParser::parse(Rule::main, "blur 1;\nbrighten 2")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+
+        assert_eq!(
+            Ok(vec![Operation::Blur(1.0), Operation::Brighten(2)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_parse_next_line_versions_fin_with_sep_eoi() {
+        let pairs = SICParser::parse(Rule::main, "blur 1;\nbrighten 2;")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+
+        assert_eq!(
+            Ok(vec![Operation::Blur(1.0), Operation::Brighten(2)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_parse_next_line_versions_fin_with_sep_with_trailing_spaces_eoi() {
+        let pairs = SICParser::parse(Rule::main, "blur 1;\nbrighten 2;    ")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+
+        assert_eq!(
+            Ok(vec![Operation::Blur(1.0), Operation::Brighten(2)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_parse_single_line_versions_fin_with_eoi() {
+        let pairs = SICParser::parse(Rule::main, "blur 1; brighten 2")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+
+        assert_eq!(
+            Ok(vec![Operation::Blur(1.0), Operation::Brighten(2)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_parse_single_line_versions_fin_with_eoi_2() {
+        let pairs = SICParser::parse(Rule::main, "blur 1;brighten 2")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+
+        assert_eq!(
+            Ok(vec![Operation::Blur(1.0), Operation::Brighten(2)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_parse_single_line_versions_fin_with_sep_with_trailing_spaces_eoi() {
+        let pairs = SICParser::parse(Rule::main, "blur 1; brighten 2;   ")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+
+        assert_eq!(
+            Ok(vec![Operation::Blur(1.0), Operation::Brighten(2)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parse_single_line_versions_require_sep() {
+        SICParser::parse(Rule::main, "blur 4 blur 3").unwrap_or_else(|e| panic!("error: {:?}", e));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parse_single_line_versions_require_sep_2() {
+        SICParser::parse(Rule::main, "blur 4\nblur 3").unwrap_or_else(|e| panic!("error: {:?}", e));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parse_single_line_versions_require_sep_3() {
+        SICParser::parse(Rule::main, "blur 4 blur 3;").unwrap_or_else(|e| panic!("error: {:?}", e));
+    }
+
+    #[test]
+    fn test_parse_single_line_versions_fin_with_sep_eoi() {
+        let pairs = SICParser::parse(Rule::main, "blur 1;brighten 2;")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+
+        assert_eq!(
+            Ok(vec![Operation::Blur(1.0), Operation::Brighten(2)]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_parse_require_space_between_operation_id_and_value() {
+        SICParser::parse(Rule::main, "blur1; brighten 2")
+            .unwrap_or_else(|e| panic!("error: {:?}", e));
+    }
+
+    #[test]
     fn test_blur_single_stmt_parse_correct() {
         let pairs = SICParser::parse(Rule::main, "blur 15;")
             .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
@@ -414,57 +516,63 @@ mod tests {
 
     #[test]
     fn test_filter3x3_triplets_f3_sep_newline() {
-        let pairs = SICParser::parse(Rule::main, "filter3x3\n0 0 0\n1 1 1\n2 2 3.0;")
-            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
-        assert_eq!(
-            Ok(vec![Operation::Filter3x3(ArrayVec::from([
-                0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0
-            ]))]),
-            parse_image_operations(pairs)
-        );
+        let pairs = SICParser::parse(Rule::main, "filter3x3\n0 0 0\n1 1 1\n2 2 3.0;");
+
+        assert!(pairs.is_err())
     }
 
-    #[test]
-    fn test_filter3x3_triplets_f3_weird_spacing() {
-        let pairs = SICParser::parse(Rule::main, "filter3x3\t\t\r\n\n0\n0.0\t0\n1 1.0 1\n2.0 2 3")
-            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
-        assert_eq!(
-            Ok(vec![Operation::Filter3x3(ArrayVec::from([
-                0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0
-            ]))]),
-            parse_image_operations(pairs)
-        );
-    }
+    // START_TODO
+    // TODO{}: arbitrary whitespace within commands and command arguments. Should it be allowed?
+    // related to the following two test cases.
+
+    //    #[test]
+    //    fn test_filter3x3_triplets_f3_weird_spacing() {
+    //        let pairs = SICParser::parse(
+    //            Rule::main,
+    //            "blur 3",
+    //        )
+    //        .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+    //        assert_eq!(
+    //            Ok(vec![Operation::Blur(3.0)]),
+    //            parse_image_operations(pairs)
+    //        );
+    //    }
+
+    //    #[test]
+    //    fn test_filter3x3_triplets_f3_weird_spacing() {
+    //        let pairs = SICParser::parse(
+    //            Rule::main,
+    //            "filter3x3 0  0.0 0 1 1.0 1 2.0 2   3",
+    //        )
+    //        .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+    //        assert_eq!(
+    //            Ok(vec![Operation::Filter3x3(ArrayVec::from([
+    //                0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0
+    //            ]))]),
+    //            parse_image_operations(pairs)
+    //        );
+    //    }
+    // END_TODO
 
     #[test]
     fn test_filter3x3_triplets_f3_tabbed_spacing() {
-        let pairs = SICParser::parse(Rule::main, "filter3x3 0 0 0\t1 1 1\t2 2 3;")
-            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
-        assert_eq!(
-            Ok(vec![Operation::Filter3x3(ArrayVec::from([
-                0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0
-            ]))]),
-            parse_image_operations(pairs)
-        );
+        let pairs = SICParser::parse(Rule::main, "filter3x3 0 0 0\t1 1 1\t2 2 3;");
+
+        assert!(pairs.is_err())
     }
 
     #[test]
     fn test_filter3x3_triplets_f3_indented_newlines() {
-        let pairs = SICParser::parse(Rule::main, "filter3x3\n\t0 0 0\n\t1 1 1\n\t2 2 3")
-            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
-        assert_eq!(
-            Ok(vec![Operation::Filter3x3(ArrayVec::from([
-                0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 2.0, 2.0, 3.0
-            ]))]),
-            parse_image_operations(pairs)
-        );
+        let pairs = SICParser::parse(Rule::main, "filter3x3\n\t0 0 0\n\t1 1 1\n\t2 2 3");
+
+        assert!(pairs.is_err())
     }
 
     #[test]
     fn test_filter3x3_duo_filter3x3() {
         let pairs = SICParser::parse(
             Rule::main,
-            "filter3x3 1.9 2 3 | 4 5.9 6 | 7 8 9.9\nfilter3x3 10.9 2 3 4 11.9 6 7 8 12.9",
+            "filter3x3 1.9 2 3 | 4 5.9 6 | 7 8 9.9;\nfilter3x3 10.9 2 3 4 11.9 6 7 8 12.9",
         )
         .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
 
@@ -734,7 +842,7 @@ mod tests {
     fn test_multi_whitespace_2() {
         let pairs = SICParser::parse(
             Rule::main,
-            "fliph    ; flipv   ;   \t\t resize 100 200; blur 10;",
+            "fliph    ; flipv   ;      resize 100 200; blur 10;",
         )
         .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
         assert_eq!(
@@ -750,7 +858,7 @@ mod tests {
 
     #[test]
     fn test_multi_whitespace_3() {
-        let pairs = SICParser::parse(Rule::main, "fliph;\nflipv;\nresize 100 200;\n\tblur 10;")
+        let pairs = SICParser::parse(Rule::main, "fliph;\nflipv;\nresize 100 200;\nblur 10;")
             .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
         assert_eq!(
             Ok(vec![
@@ -779,8 +887,8 @@ mod tests {
     }
 
     #[test]
-    fn test_multi_sep_optional() {
-        let pairs = SICParser::parse(Rule::main, "fliph flipv; resize 100 200 blur 10")
+    fn test_multi_sep() {
+        let pairs = SICParser::parse(Rule::main, "fliph; flipv;  resize 100 200;\nblur 10")
             .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
         assert_eq!(
             Ok(vec![


### PR DESCRIPTION
Makes the `;` separator a requirement, for improved reading clarity. 

---

issue: #86 