### PR TITLE
Re-integrate combostew as sub crates: config, conversion+io, testing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,14 +95,6 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "combostew"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "image 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,17 +423,22 @@ name = "sic"
 version = "0.9.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sic_config 0.1.0",
  "sic_core 0.1.0",
  "sic_image_engine 0.1.0",
+ "sic_io 0.1.0",
  "sic_parser 0.1.0",
  "sic_user_manual 0.1.0",
 ]
 
 [[package]]
+name = "sic_config"
+version = "0.1.0"
+
+[[package]]
 name = "sic_core"
 version = "0.1.0"
 dependencies = [
- "combostew 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "image 0.21.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -453,6 +450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sic_io"
+version = "0.1.0"
+dependencies = [
+ "sic_config 0.1.0",
+ "sic_core 0.1.0",
+ "sic_testing 0.1.0",
+]
+
+[[package]]
 name = "sic_parser"
 version = "0.1.0"
 dependencies = [
@@ -461,6 +467,10 @@ dependencies = [
  "sic_core 0.1.0",
  "sic_image_engine 0.1.0",
 ]
+
+[[package]]
+name = "sic_testing"
+version = "0.1.0"
 
 [[package]]
 name = "sic_user_manual"
@@ -569,7 +579,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
-"checksum combostew 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "23de8da6390c8f4948060a3a94a6d051fbc803982a6da5c918686ab5b0f36ad5"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,19 @@ members = [
   "sic_user_manual",
 
   # former combostew modules
-  "sic_image_engine"
+  "sic_config",
+  "sic_image_engine",
+  "sic_io",
+
+  "sic_testing",
 ]
 
 [dependencies]
 clap = "2.32.0"
 sic_core = { path = "sic_core" }
+sic_config = { path = "sic_config" }
 sic_image_engine = { path = "sic_image_engine" }
+sic_io  = { path = "sic_io" }
 sic_parser = { path = "sic_parser" }
 sic_user_manual  = { path = "sic_user_manual" }
 

--- a/sic_config/Cargo.toml
+++ b/sic_config/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sic_config"
+version = "0.1.0"
+authors = ["Martijn Gribnau <garm@ilumeo.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/sic_config/src/lib.rs
+++ b/sic_config/src/lib.rs
@@ -1,0 +1,121 @@
+// Currently uses String instead of &str for easier initial development (i.e. no manual lifetimes).
+// It should be replaced by &str where possible.
+#[derive(Debug)]
+pub struct Config {
+    pub tool_name: &'static str,
+
+    // Display license of this software or its dependencies.
+    pub licenses: Vec<SelectedLicenses>,
+
+    // Format to which an image will be converted (enforced).
+    pub forced_output_format: Option<String>,
+
+    // --disable-automatic-color-type-adjustment
+    pub disable_automatic_color_type_adjustment: bool,
+
+    pub encoding_settings: FormatEncodingSettings,
+
+    // output path
+    pub output: Option<String>,
+
+    // Application specific settings. Only supports enum items defined in `ConfigItem`.
+    pub application_specific: Vec<ConfigItem>,
+}
+
+// TODO{}: This is suboptimal, since depending crates can't define their own types...
+#[derive(Debug)]
+pub enum ConfigItem {
+    OptionStringItem(Option<String>),
+}
+
+#[derive(Debug)]
+pub enum SelectedLicenses {
+    ThisSoftware,
+    Dependencies,
+}
+
+#[derive(Debug)]
+pub struct FormatEncodingSettings {
+    pub jpeg_settings: JPEGEncodingSettings,
+
+    pub pnm_settings: PNMEncodingSettings,
+}
+
+#[derive(Debug)]
+pub struct JPEGEncodingSettings {
+    // Valid values are actually 1...100 (inclusive)
+    pub quality: u8,
+}
+
+impl JPEGEncodingSettings {
+    const JPEG_ENCODING_QUALITY_DEFAULT: u8 = 80;
+
+    // Param:
+    // * quality: (present?, value)
+    pub fn new_result(quality: (bool, Option<&str>)) -> Result<JPEGEncodingSettings, String> {
+        let proposed_quality = match quality.1 {
+            Some(v) => v
+                .parse::<u8>()
+                .map_err(|_| "JPEG Encoding Settings error: QUALITY is not a valid number.".into()),
+            None if !quality.0 => Ok(JPEGEncodingSettings::JPEG_ENCODING_QUALITY_DEFAULT),
+            None => Err("JPEG Encoding Settings error: Unreachable".into()),
+        };
+
+        fn within_range(v: u8) -> Result<JPEGEncodingSettings, String> {
+            // Upper bound is exclusive with .. syntax.
+            // When the `range_contains` feature will be stabilised Range.contains(&v)
+            // should be used instead.
+            const ALLOWED_RANGE: std::ops::Range<u8> = 1..101;
+            if v >= ALLOWED_RANGE.start && v < ALLOWED_RANGE.end {
+                let res = JPEGEncodingSettings { quality: v };
+
+                Ok(res)
+            } else {
+                Err("JPEG Encoding Settings error: --jpeg-encoding-quality requires a number between 1 and 100.".into())
+            }
+        }
+
+        proposed_quality.and_then(within_range)
+    }
+}
+
+#[derive(Debug)]
+pub struct PNMEncodingSettings {
+    // Use ascii for PBM, PGM or PPM. Not compatible with PAM.
+    pub ascii: bool,
+}
+
+impl PNMEncodingSettings {
+    pub fn new(ascii: bool) -> PNMEncodingSettings {
+        PNMEncodingSettings { ascii }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn jpeg_in_quality_range_lower_bound_inside() {
+        let value: &str = "1";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_ok())
+    }
+
+    #[test]
+    fn jpeg_in_quality_range_lower_bound_outside() {
+        let value: &str = "0";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_err())
+    }
+
+    #[test]
+    fn jpeg_in_quality_range_upper_bound_inside() {
+        let value: &str = "100";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_ok())
+    }
+
+    #[test]
+    fn jpeg_in_quality_range_upper_bound_outside() {
+        let value: &str = "101";
+        assert!(JPEGEncodingSettings::new_result((true, Some(value))).is_err())
+    }
+}

--- a/sic_core/Cargo.toml
+++ b/sic_core/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 edition = "2018"
 
 [dependencies]
-combostew = "0.3.0"
+#combostew = "0.3.0"
 image = "0.21.0"

--- a/sic_core/src/lib.rs
+++ b/sic_core/src/lib.rs
@@ -1,5 +1,4 @@
 /// This crate reexports the crates which are used by all (or most) sub crates as defined in the
 /// sic crate.
 /// The purpose of this re-export is to have equal versions for all sic sub crates.
-pub use combostew;
 pub use image;

--- a/sic_io/Cargo.toml
+++ b/sic_io/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sic_io"
+version = "0.1.0"
+authors = ["Martijn Gribnau <garm@ilumeo.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sic_core = { path = "../sic_core" }
+sic_config = { path = "../sic_config" }
+
+[dev-dependencies]
+sic_testing = { path = "../sic_testing" }

--- a/sic_io/src/conversion.rs
+++ b/sic_io/src/conversion.rs
@@ -1,0 +1,295 @@
+use std::io::{self, Write};
+use std::path::Path;
+
+use sic_config::Config;
+use sic_core::image;
+
+pub struct ConversionProcessor<'a> {
+    image: &'a image::DynamicImage,
+    output_format: image::ImageOutputFormat,
+}
+
+impl<'a> ConversionProcessor<'a> {
+    pub fn new(
+        image: &image::DynamicImage,
+        output_format: image::ImageOutputFormat,
+    ) -> ConversionProcessor {
+        ConversionProcessor {
+            image,
+            output_format,
+        }
+    }
+
+    pub fn process(&self, config: &Config) -> Result<(), String> {
+        let output_format = self.output_format.clone();
+        let color_processing =
+            &ConversionProcessor::preprocess_color_type(&config, &self.image, &output_format);
+
+        let export_buffer = match color_processing {
+            Some(replacement) => replacement,
+            None => &self.image,
+        };
+
+        match &config.output {
+            // Some() => write to file
+            Some(v) => ConversionProcessor::save_to_file(&export_buffer, output_format, v),
+            // None => write to stdout
+            None => ConversionProcessor::export_to_stdout(&export_buffer, output_format),
+        }
+    }
+
+    // Some image output format types require color type preprocessing.
+    // This is the case if the output image format does not support the color type held by the image buffer prior to the final conversion.
+    //
+    // The open question remains as follows: does a user expect for an image to be able to convert to a format even if the color type is not supported?
+    // And even if the user does, should we?
+    // I suspect that users expect that color type conversions should happen automatically.
+    //
+    // Testing also showed that even bmp with full black full white pixels do not convert correctly as of now. Why exactly is unclear;
+    // Perhaps the color type of the bmp formatted test image?
+    //
+    // If preprocessing of the color type took place, Some(<new image>) will be returned.
+    // If no preprocessing of the color type is required will return None.
+    fn preprocess_color_type(
+        config: &Config,
+        image: &image::DynamicImage,
+        output_format: &image::ImageOutputFormat,
+    ) -> Option<image::DynamicImage> {
+        if config.disable_automatic_color_type_adjustment {
+            return None;
+        }
+
+        match output_format {
+            image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Bitmap(_)) => {
+                Some(image.grayscale())
+            }
+            image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Graymap(_)) => {
+                Some(image.grayscale())
+            }
+            image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Pixmap(_)) => {
+                Some(image::DynamicImage::ImageRgb8(image.to_rgb()))
+            }
+            _ => None,
+        }
+    }
+
+    fn save_to_file<P: AsRef<Path>>(
+        buffer: &image::DynamicImage,
+        format: image::ImageOutputFormat,
+        path: P,
+    ) -> Result<(), String> {
+        let mut out = std::fs::File::create(path).map_err(|err| err.to_string())?;
+
+        buffer
+            .write_to(&mut out, format)
+            .map_err(|err| err.to_string())
+    }
+
+    fn export_to_stdout(
+        buffer: &image::DynamicImage,
+        format: image::ImageOutputFormat,
+    ) -> Result<(), String> {
+        let mut write_buffer = Vec::new();
+
+        buffer
+            .write_to(&mut write_buffer, format)
+            .map_err(|err| err.to_string())?;
+
+        io::stdout()
+            .write(&write_buffer)
+            .map(|_| ())
+            .map_err(|err| err.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use sic_config::{
+        Config, ConfigItem, FormatEncodingSettings, JPEGEncodingSettings, PNMEncodingSettings,
+    };
+    use sic_testing::{clean_up_output_path, setup_output_path, setup_test_image};
+
+    use super::*;
+
+    // Individual tests:
+
+    const INPUT: &str = "rainbow_8x6.bmp";
+    const OUTPUT: &str = "conversion_rainbow_8x6.png";
+
+    fn setup_dummy_config(output: &str) -> Config {
+        Config {
+            tool_name: env!("CARGO_PKG_NAME"),
+            licenses: vec![],
+            forced_output_format: None,
+            disable_automatic_color_type_adjustment: false,
+
+            encoding_settings: FormatEncodingSettings {
+                jpeg_settings: JPEGEncodingSettings::new_result((false, None))
+                    .expect("Invalid jpeg settings"),
+                pnm_settings: PNMEncodingSettings::new(false),
+            },
+
+            output: setup_output_path(output).to_str().map(|v| v.into()),
+
+            application_specific: vec![
+                ConfigItem::OptionStringItem(None),
+                ConfigItem::OptionStringItem(None),
+            ],
+        }
+    }
+
+    #[test]
+    fn will_output_file_be_created() {
+        let our_output = &format!("will_output_file_be_created{}", OUTPUT); // this is required because tests are run in parallel, and the creation, or deletion can collide.
+
+        let buffer = image::open(setup_test_image(INPUT)).expect("Can't open test file.");
+        let example_output_format = image::ImageOutputFormat::PNG;
+        let settings = setup_dummy_config(our_output);
+
+        let conversion_processor = ConversionProcessor::new(&buffer, example_output_format);
+        conversion_processor
+            .process(&settings)
+            .expect("Unable to save file to the test computer.");
+
+        assert!(setup_output_path(our_output).exists());
+
+        clean_up_output_path(our_output);
+    }
+
+    #[test]
+    fn has_png_extension() {
+        let our_output = &format!("has_png_extension{}", OUTPUT);
+
+        let buffer = image::open(setup_test_image(INPUT)).expect("Can't open test file.");
+        let example_output_format = image::ImageOutputFormat::PNG;
+        let settings = setup_dummy_config(our_output);
+
+        let conversion_processor = ConversionProcessor::new(&buffer, example_output_format);
+        conversion_processor
+            .process(&settings)
+            .expect("Unable to save file to the test computer.");
+
+        assert_eq!(
+            Some(std::ffi::OsStr::new("png")),
+            setup_output_path(our_output).extension()
+        );
+
+        clean_up_output_path(our_output);
+    }
+
+    #[test]
+    fn is_png_file() {
+        let our_output = &format!("is_png_file{}", OUTPUT);
+
+        let buffer = image::open(setup_test_image(INPUT)).expect("Can't open test file.");
+        let example_output_format = image::ImageOutputFormat::PNG;
+        let settings = setup_dummy_config(our_output);
+
+        let conversion_processor = ConversionProcessor::new(&buffer, example_output_format);
+        conversion_processor
+            .process(&settings)
+            .expect("Unable to save file to the test computer.");
+
+        let mut file = std::fs::File::open(setup_output_path(our_output))
+            .expect("Unable to find file we made.");
+        let mut bytes = vec![];
+        file.read_to_end(&mut bytes)
+            .expect("Unable to finish reading our test image.");
+
+        assert_eq!(
+            image::ImageFormat::PNG,
+            image::guess_format(&bytes).expect("Format could not be guessed.")
+        );
+
+        clean_up_output_path(our_output);
+    }
+
+    // Multi tests:
+    // Below all supported formats are testsed using the inputs listed below.
+
+    const INPUT_MULTI: &[&str] = &["blackwhite_2x2.bmp", "palette_4x4.png"];
+    const INPUT_FORMATS: &[&str] = &[
+        "bmp", "gif", "ico", "jpg", "jpeg", "png", "pbm", "pgm", "ppm", "pam",
+    ];
+    const OUTPUT_FORMATS: &[image::ImageOutputFormat] = &[
+        image::ImageOutputFormat::BMP,
+        image::ImageOutputFormat::GIF,
+        image::ImageOutputFormat::ICO,
+        image::ImageOutputFormat::JPEG(80),
+        image::ImageOutputFormat::JPEG(80),
+        image::ImageOutputFormat::PNG,
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Bitmap(
+            image::pnm::SampleEncoding::Binary,
+        )),
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Graymap(
+            image::pnm::SampleEncoding::Binary,
+        )),
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Pixmap(
+            image::pnm::SampleEncoding::Binary,
+        )),
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::ArbitraryMap),
+    ];
+
+    const EXPECTED_VALUES: &[image::ImageFormat] = &[
+        image::ImageFormat::BMP,
+        image::ImageFormat::GIF,
+        image::ImageFormat::ICO,
+        image::ImageFormat::JPEG,
+        image::ImageFormat::JPEG,
+        image::ImageFormat::PNG,
+        image::ImageFormat::PNM,
+        image::ImageFormat::PNM,
+        image::ImageFormat::PNM,
+        image::ImageFormat::PNM,
+    ];
+
+    fn test_conversion_with_header_match(
+        input: &str,
+        enc_format: &str,
+        to_format: image::ImageOutputFormat,
+        expected_format: image::ImageFormat,
+    ) {
+        let our_output = &format!("header_match_conversion.{}", enc_format);
+
+        let buffer = image::open(setup_test_image(input)).expect("Can't open test file.");
+        let settings = setup_dummy_config(our_output);
+
+        let conversion_processor = ConversionProcessor::new(&buffer, to_format);
+        conversion_processor
+            .process(&settings)
+            .expect("Unable to save file to the test computer.");
+
+        let mut file = std::fs::File::open(setup_output_path(our_output))
+            .expect("Unable to find file we made.");
+        let mut bytes = vec![];
+        file.read_to_end(&mut bytes)
+            .expect("Unable to finish reading our test image.");
+
+        assert_eq!(
+            expected_format,
+            image::guess_format(&bytes).expect("Format could not be guessed.")
+        );
+
+        clean_up_output_path(our_output);
+    }
+
+    #[test]
+    fn test_conversions_with_header_match() {
+        for test_image in INPUT_MULTI.iter() {
+            let zipped = INPUT_FORMATS
+                .iter()
+                .zip(OUTPUT_FORMATS.iter().cloned())
+                .zip(EXPECTED_VALUES.iter());
+
+            for ((ext, to_format), expected_format) in zipped {
+                println!(
+                    "testing `test_conversion_with_header_match`, converting {} => : {}",
+                    test_image, ext
+                );
+                test_conversion_with_header_match(test_image, ext, to_format, *expected_format);
+            }
+        }
+    }
+}

--- a/sic_io/src/encoding_format.rs
+++ b/sic_io/src/encoding_format.rs
@@ -1,0 +1,464 @@
+use std::path::Path;
+
+use sic_config::Config;
+use sic_core::image;
+
+const DEFAULT_PIPED_OUTPUT_FORMAT: image::ImageOutputFormat = image::ImageOutputFormat::BMP;
+
+#[derive(Debug, Default)]
+pub struct EncodingFormatDecider;
+
+impl EncodingFormatDecider {
+    pub fn process(&self, config: &Config) -> Result<image::ImageOutputFormat, String> {
+        EncodingFormatDecider::compute_format(&config)
+    }
+
+    // return: Ok: valid extension, err: invalid i.e. no extension or no valid output path
+    fn get_output_extension(config: &Config) -> Result<String, String> {
+        match &config.output {
+            Some(v) => {
+                let path = &Path::new(v);
+                let extension = path.extension();
+
+                extension
+                    .and_then(std::ffi::OsStr::to_str)
+                    .ok_or_else(|| "No extension was found".into())
+                    .map(str::to_lowercase)
+            }
+            None => Err("No valid output path found (type: efd/ext)".into()),
+        }
+    }
+
+    fn sample_encoding(config: &Config) -> image::pnm::SampleEncoding {
+        if config.encoding_settings.pnm_settings.ascii {
+            image::pnm::SampleEncoding::Ascii
+        } else {
+            image::pnm::SampleEncoding::Binary
+        }
+    }
+
+    // <output format type as String, error message as String>
+    fn determine_format_string(config: &Config) -> Result<String, String> {
+        if let Some(v) = &config.forced_output_format {
+            Ok(v.to_lowercase())
+        } else {
+            EncodingFormatDecider::get_output_extension(config)
+        }
+    }
+
+    fn determine_format_from_str(
+        config: &Config,
+        identifier: &str,
+    ) -> Result<image::ImageOutputFormat, String> {
+        match identifier {
+            "bmp" => Ok(image::ImageOutputFormat::BMP),
+            "gif" => Ok(image::ImageOutputFormat::GIF),
+            "ico" => Ok(image::ImageOutputFormat::ICO),
+            "jpeg" | "jpg" => Ok(image::ImageOutputFormat::JPEG(
+                config.encoding_settings.jpeg_settings.quality,
+            )),
+            "png" => Ok(image::ImageOutputFormat::PNG),
+            "pbm" => {
+                let sample_encoding = EncodingFormatDecider::sample_encoding(&config);
+
+                Ok(image::ImageOutputFormat::PNM(
+                    image::pnm::PNMSubtype::Bitmap(sample_encoding),
+                ))
+            }
+            "pgm" => {
+                let sample_encoding = EncodingFormatDecider::sample_encoding(&config);
+
+                Ok(image::ImageOutputFormat::PNM(
+                    image::pnm::PNMSubtype::Graymap(sample_encoding),
+                ))
+            }
+            "ppm" => {
+                let sample_encoding = EncodingFormatDecider::sample_encoding(&config);
+
+                Ok(image::ImageOutputFormat::PNM(
+                    image::pnm::PNMSubtype::Pixmap(sample_encoding),
+                ))
+            }
+            "pam" => Ok(image::ImageOutputFormat::PNM(
+                image::pnm::PNMSubtype::ArbitraryMap,
+            )),
+            _ => Err(format!(
+                "No supported image output format was found, input: {}.",
+                identifier
+            )),
+        }
+    }
+
+    fn compute_format(config: &Config) -> Result<image::ImageOutputFormat, String> {
+        if config.output.is_none() && config.forced_output_format.is_none() {
+            return Ok(DEFAULT_PIPED_OUTPUT_FORMAT);
+        }
+
+        // 1. get the format type
+        //   a. if not -f or and we have an extension
+        //      use the extension to determine the type
+        //   b. if  -f v
+        //      use v to determine the type
+        //   c. else
+        //      unable to determine format error
+        let format = EncodingFormatDecider::determine_format_string(&config);
+
+        // 2. match on additional options such as PNM's subtype or JPEG's quality
+        //    ensure that user set cases are above default cases
+        EncodingFormatDecider::determine_format_from_str(&config, &format?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use sic_config::{
+        Config, ConfigItem, FormatEncodingSettings, JPEGEncodingSettings, PNMEncodingSettings,
+    };
+    use sic_testing::*;
+
+    use super::*;
+
+    const OUTPUT_NO_EXT: &str = "dont_care";
+    const INPUT_FORMATS: &[&str] = &[
+        "bmp", "gif", "ico", "jpg", "jpeg", "png", "pbm", "pgm", "ppm", "pam",
+    ];
+    const EXPECTED_VALUES: &[image::ImageOutputFormat] = &[
+        image::ImageOutputFormat::BMP,
+        image::ImageOutputFormat::GIF,
+        image::ImageOutputFormat::ICO,
+        image::ImageOutputFormat::JPEG(80),
+        image::ImageOutputFormat::JPEG(80),
+        image::ImageOutputFormat::PNG,
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Bitmap(
+            image::pnm::SampleEncoding::Binary,
+        )),
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Graymap(
+            image::pnm::SampleEncoding::Binary,
+        )),
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Pixmap(
+            image::pnm::SampleEncoding::Binary,
+        )),
+        image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::ArbitraryMap),
+    ];
+
+    fn setup_dummy_config(
+        output: &str,
+        ext: &str,
+        force_format: Option<String>,
+        pnm_ascii: bool,
+    ) -> Config {
+        Config {
+            tool_name: env!("CARGO_PKG_NAME"),
+            licenses: vec![],
+            forced_output_format: force_format,
+            disable_automatic_color_type_adjustment: false,
+
+            encoding_settings: FormatEncodingSettings {
+                jpeg_settings: JPEGEncodingSettings::new_result((false, None))
+                    .expect("Invalid jpeg settings"),
+                pnm_settings: PNMEncodingSettings::new(pnm_ascii),
+            },
+
+            output: setup_output_path(&format!("{}.{}", output, ext))
+                .to_str()
+                .map(|v| v.into()),
+
+            application_specific: vec![
+                ConfigItem::OptionStringItem(None),
+                ConfigItem::OptionStringItem(None),
+            ],
+        }
+    }
+
+    fn test_with_extension(ext: &str, expected: &image::ImageOutputFormat) {
+        let output_name = &format!("encoding_processing_w_ext_{}", OUTPUT_NO_EXT);
+
+        let settings = setup_dummy_config(output_name, ext, None, false);
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&settings)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(*expected, result);
+    }
+
+    fn test_with_force_format(format: &str, expected: &image::ImageOutputFormat) {
+        let output_name = &format!("encoding_processing_w_ff_{}", OUTPUT_NO_EXT);
+
+        let settings = setup_dummy_config(output_name, "", Some(String::from(format)), false);
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&settings)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(*expected, result);
+    }
+
+    #[test]
+    fn test_with_extensions_with_defaults() {
+        let zipped = INPUT_FORMATS.iter().zip(EXPECTED_VALUES.iter());
+
+        for (ext, exp) in zipped {
+            println!("testing `test_with_extension`: {}", ext);
+            test_with_extension(ext, exp);
+        }
+    }
+
+    #[test]
+    fn test_with_force_formats_with_defaults() {
+        let zipped = INPUT_FORMATS.iter().zip(EXPECTED_VALUES.iter());
+
+        for (format, exp) in zipped {
+            println!("testing `test_with_force_format`: {}", format);
+            test_with_force_format(format, exp);
+        }
+    }
+
+    #[test]
+    fn test_with_extension_jpg_and_force_format_png() {
+        let output_name = &format!("encoding_processing_w_ext_and_ff_{}", OUTPUT_NO_EXT);
+
+        let settings = setup_dummy_config(output_name, "jpg", Some(String::from("png")), false);
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&settings)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(image::ImageOutputFormat::PNG, result);
+    }
+
+    #[test]
+    fn test_with_extension_and_ascii_pbm() {
+        let output_name = &format!("encoding_processing_ascii_pbm_{}", OUTPUT_NO_EXT);
+
+        let settings = setup_dummy_config(output_name, "pbm", None, true);
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&settings)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(
+            image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Bitmap(
+                image::pnm::SampleEncoding::Ascii,
+            )),
+            result
+        );
+    }
+
+    #[test]
+    fn test_with_extension_and_ascii_pgm() {
+        let output_name = &format!("encoding_processing_ascii_pgm_{}", OUTPUT_NO_EXT);
+
+        let settings = setup_dummy_config(output_name, "pgm", None, true);
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&settings)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(
+            image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Graymap(
+                image::pnm::SampleEncoding::Ascii,
+            )),
+            result
+        );
+    }
+
+    #[test]
+    fn test_with_extension_and_ascii_ppm() {
+        let output_name = &format!("encoding_processing_ascii_ppm_{}", OUTPUT_NO_EXT);
+
+        let settings = setup_dummy_config(output_name, "ppm", None, true);
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&settings)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(
+            image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::Pixmap(
+                image::pnm::SampleEncoding::Ascii,
+            )),
+            result
+        );
+    }
+
+    #[test]
+    fn test_with_extension_and_ascii_pam_doesnt_care() {
+        // PAM is not influenced by the PNM ascii setting
+        let output_name = &format!(
+            "encoding_processing_ascii_pam_doesnt_care_{}",
+            OUTPUT_NO_EXT
+        );
+
+        let settings = setup_dummy_config(output_name, "pam", None, true);
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&settings)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(
+            image::ImageOutputFormat::PNM(image::pnm::PNMSubtype::ArbitraryMap),
+            result
+        );
+    }
+
+    #[test]
+    fn test_jpeg_custom_quality() {
+        let jpeg_conf = Config {
+            tool_name: env!("CARGO_PKG_NAME"),
+            licenses: vec![],
+            forced_output_format: None,
+            disable_automatic_color_type_adjustment: false,
+
+            encoding_settings: FormatEncodingSettings {
+                jpeg_settings: JPEGEncodingSettings::new_result((true, Some("40")))
+                    .expect("Invalid jpeg settings"),
+                pnm_settings: PNMEncodingSettings::new(false),
+            },
+
+            output: setup_output_path("encoding_processing_jpeg_quality_valid.jpg")
+                .to_str()
+                .map(|v| v.into()),
+
+            application_specific: vec![
+                ConfigItem::OptionStringItem(None),
+                ConfigItem::OptionStringItem(None),
+            ],
+        };
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let result = conversion_processor
+            .process(&jpeg_conf)
+            .expect("Failed to compute image format.");
+
+        assert_eq!(image::ImageOutputFormat::JPEG(40), result);
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_output_unsupported_extension() {
+        let jpeg_conf = Config {
+            tool_name: env!("CARGO_PKG_NAME"),
+            licenses: vec![],
+            forced_output_format: None,
+            disable_automatic_color_type_adjustment: false,
+
+            encoding_settings: FormatEncodingSettings {
+                jpeg_settings: JPEGEncodingSettings { quality: 90 },
+                pnm_settings: PNMEncodingSettings::new(false),
+            },
+
+            output: setup_output_path("encoding_processing_invalid.😉")
+                .to_str()
+                .map(|v| v.into()),
+
+            application_specific: vec![
+                ConfigItem::OptionStringItem(None),
+                ConfigItem::OptionStringItem(None),
+            ],
+        };
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let _ = conversion_processor
+            .process(&jpeg_conf)
+            .expect("Failed to compute image format.");
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_output_no_ext_or_ff() {
+        let jpeg_conf = Config {
+            tool_name: env!("CARGO_PKG_NAME"),
+            licenses: vec![],
+            forced_output_format: None,
+            disable_automatic_color_type_adjustment: false,
+
+            encoding_settings: FormatEncodingSettings {
+                jpeg_settings: JPEGEncodingSettings { quality: 90 },
+                pnm_settings: PNMEncodingSettings::new(false),
+            },
+
+            output: setup_output_path("encoding_processing_invalid.")
+                .to_str()
+                .map(|v| v.into()),
+
+            application_specific: vec![
+                ConfigItem::OptionStringItem(None),
+                ConfigItem::OptionStringItem(None),
+            ],
+        };
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let _ = conversion_processor
+            .process(&jpeg_conf)
+            .expect("Failed to compute image format.");
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_output_unsupported_ff_with_ext() {
+        let jpeg_conf = Config {
+            tool_name: env!("CARGO_PKG_NAME"),
+            licenses: vec![],
+            forced_output_format: Some("OiOi".into()), // unsupported format
+            disable_automatic_color_type_adjustment: false,
+
+            encoding_settings: FormatEncodingSettings {
+                jpeg_settings: JPEGEncodingSettings { quality: 90 },
+                pnm_settings: PNMEncodingSettings::new(false),
+            },
+
+            output: setup_output_path("encoding_processing_invalid.jpg")
+                .to_str()
+                .map(|v| v.into()),
+
+            application_specific: vec![
+                ConfigItem::OptionStringItem(None),
+                ConfigItem::OptionStringItem(None),
+            ],
+        };
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let _ = conversion_processor
+            .process(&jpeg_conf)
+            .expect("Unable to save file to the test computer");
+    }
+
+    #[should_panic]
+    #[test]
+    fn test_output_unsupported_ff_without_ext() {
+        let jpeg_conf = Config {
+            tool_name: env!("CARGO_PKG_NAME"),
+            licenses: vec![],
+            forced_output_format: Some("OiOi".into()), // unsupported format
+            disable_automatic_color_type_adjustment: false,
+
+            encoding_settings: FormatEncodingSettings {
+                jpeg_settings: JPEGEncodingSettings { quality: 90 },
+                pnm_settings: PNMEncodingSettings::new(false),
+            },
+
+            output: setup_output_path("encoding_processing_invalid")
+                .to_str()
+                .map(|v| v.into()),
+
+            application_specific: vec![
+                ConfigItem::OptionStringItem(None),
+                ConfigItem::OptionStringItem(None),
+            ],
+        };
+
+        let conversion_processor = EncodingFormatDecider::default();
+        let _ = conversion_processor
+            .process(&jpeg_conf)
+            .expect("Unable to save file to the test computer");
+    }
+
+    // TODO{}: test bad cases, edges
+}

--- a/sic_io/src/lib.rs
+++ b/sic_io/src/lib.rs
@@ -1,0 +1,80 @@
+use std::env::args;
+use std::io::stdin;
+use std::io::Read;
+use std::path::Path;
+
+use sic_config::Config;
+use sic_core::image;
+
+use crate::conversion::ConversionProcessor;
+use crate::encoding_format::EncodingFormatDecider;
+
+pub mod conversion;
+pub mod encoding_format;
+
+pub fn import<P: AsRef<Path>>(maybe_path: Option<P>) -> Result<image::DynamicImage, String> {
+    maybe_path.map_or_else(import_from_input_stream_sync, import_from_file_sync)
+}
+
+// TODO{foresterre}: Currently the method we use to read from the input stream is full blocking.
+//  That is, as long as no terminating signal has been received, the stream will wait for input.
+//  Perhaps we would like to read the stdin with tokio-io (async).
+//  Then we can display an error and the help page instead if the 'Complete' event has been received,
+//  but the buffer is empty.
+fn import_from_input_stream_sync() -> Result<image::DynamicImage, String> {
+    if cfg!(windows) {
+        let program_name = args().nth(0).unwrap_or_default();
+
+        eprintln!(
+            "Warning: You are using stdin as input method on the \
+             Windows platform. If you use PowerShell and the program errors with 'Unsupported image format', \
+             PowerShell assumed the binary data was text. You can either use input files instead \
+             (run {} with '--help' for more information), \
+             or run the program from 'cmd.exe' (for example: \
+             'type <INPUT_FILE> | {} -o <OUTPUT_FILE> <ARGS>').\n",
+            program_name, program_name
+        );
+    }
+
+    // We don't known the input size yet, so we allocate.
+    let mut buffer = Vec::new();
+
+    // Uses stderr because stdout is used to redirect the output image if no file is defined.
+    eprintln!(
+        "If stdin is empty, the programs waits for input until a termination \
+         signal has been received (usually you can send it by pressing Ctrl+D in your terminal)."
+    );
+
+    stdin().lock().read_to_end(&mut buffer).map_err(|err| {
+        format!(
+            "Unable to read from the stdin. Message: {}",
+            err.to_string()
+        )
+    })?;
+
+    if buffer.is_empty() {
+        return Err(
+            "Stdin was empty. To display the help page, use the `--help` flag.".to_string(),
+        );
+    }
+
+    // Uses stderr because stdout is used to redirect the output image if no file is defined.
+    eprintln!("Read {} bytes. Continuing.", buffer.len());
+
+    image::load_from_memory(&buffer).map_err(|err| err.to_string())
+}
+
+fn import_from_file_sync<P: AsRef<Path>>(path: P) -> Result<image::DynamicImage, String> {
+    image::open(path).map_err(|err| err.to_string())
+}
+
+pub fn export(
+    image: &image::DynamicImage,
+    format_decider: &EncodingFormatDecider,
+    config: &Config,
+) -> Result<(), String> {
+    format_decider.process(&config).and_then(|format| {
+        let conversion_processor = ConversionProcessor::new(&image, format);
+        conversion_processor.process(&config)
+    })
+}

--- a/sic_parser/src/rule_parser.rs
+++ b/sic_parser/src/rule_parser.rs
@@ -294,7 +294,7 @@ fn parse_triplet3x_f32(pair: Pair<'_, Rule>) -> Result<[f32; 9], String> {
 mod tests {
     use crate::SICParser;
     use pest::Parser;
-    use sic_core::combostew::image;
+    use sic_core::image;
     use sic_image_engine::engine::EnvironmentItem;
 
     use super::*;

--- a/sic_testing/Cargo.toml
+++ b/sic_testing/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "sic_testing"
+version = "0.1.0"
+authors = ["Martijn Gribnau <garm@ilumeo.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/sic_testing/src/lib.rs
+++ b/sic_testing/src/lib.rs
@@ -1,0 +1,28 @@
+use std::path::{Path, PathBuf};
+
+macro_rules! out_ {
+    ($path:expr) => {
+        &[env!("CARGO_MANIFEST_DIR"), "/../target/", $path].concat()
+    };
+}
+
+macro_rules! in_ {
+    ($path:expr) => {
+        &[env!("CARGO_MANIFEST_DIR"), "/../resources/", $path].concat()
+    };
+}
+
+/// TODO{issue#128}: rework to provide flexibility and consistency, so all modules can use this;
+
+pub fn setup_test_image(test_image_path: &str) -> PathBuf {
+    Path::new("").join(in_!(test_image_path))
+}
+
+pub fn setup_output_path(test_output_path: &str) -> PathBuf {
+    Path::new("").join(out_!(test_output_path))
+}
+
+pub fn clean_up_output_path(test_output_path: &str) {
+    std::fs::remove_file(setup_output_path(test_output_path))
+        .expect("Unable to remove file after test.");
+}

--- a/src/app/cli.rs
+++ b/src/app/cli.rs
@@ -1,8 +1,9 @@
 use clap::{App, AppSettings, Arg, ArgMatches};
-use sic_core::combostew::config::{
+use sic_config::{
     Config, ConfigItem, FormatEncodingSettings, JPEGEncodingSettings, PNMEncodingSettings,
     SelectedLicenses,
 };
+//use sic_config::*;
 
 use crate::get_tool_name;
 

--- a/src/app/custom_config.rs
+++ b/src/app/custom_config.rs
@@ -1,4 +1,4 @@
-use sic_core::combostew::config::ConfigItem;
+use sic_config::ConfigItem;
 
 fn get_config_item(c: &ConfigItem) -> Option<&str> {
     match c {

--- a/src/app/license_display.rs
+++ b/src/app/license_display.rs
@@ -1,0 +1,42 @@
+use std::process;
+
+use sic_config::{Config, SelectedLicenses};
+
+#[derive(Debug, Default)]
+pub struct LicenseDisplayProcessor<'a> {
+    self_license: &'a str,
+    dependency_licenses: &'a str,
+}
+
+impl<'a> LicenseDisplayProcessor<'a> {
+    pub fn new(self_license: &'a str, dependency_licenses: &'a str) -> LicenseDisplayProcessor<'a> {
+        LicenseDisplayProcessor {
+            self_license,
+            dependency_licenses,
+        }
+    }
+}
+
+impl<'a> LicenseDisplayProcessor<'a> {
+    fn print_licenses(&self, slice: &[SelectedLicenses], tool_name: &str) {
+        for item in slice {
+            match item {
+                SelectedLicenses::ThisSoftware => {
+                    println!(
+                        "{} image tools license:\n\n{}\n\n",
+                        tool_name, &self.self_license
+                    );
+                }
+                SelectedLicenses::Dependencies => println!("{}", &self.dependency_licenses),
+            };
+        }
+
+        if !slice.is_empty() {
+            process::exit(0);
+        }
+    }
+
+    pub fn process(&self, config: &Config) {
+        self.print_licenses(&config.licenses, &config.tool_name);
+    }
+}

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,3 +1,4 @@
 pub mod cli;
 pub mod custom_config;
+pub mod license_display;
 pub mod run_mode;

--- a/src/app/run_mode.rs
+++ b/src/app/run_mode.rs
@@ -1,13 +1,13 @@
 use clap::ArgMatches;
-use sic_core::combostew::config::Config;
-use sic_core::combostew::io::{export, import};
-use sic_core::combostew::processor::encoding_format::EncodingFormatDecider;
-use sic_core::combostew::processor::license_display::LicenseDisplayProcessor;
-use sic_core::combostew::processor::ProcessWithConfig;
+use sic_config::Config;
+
 use sic_image_engine::engine::{ImageEngine, Program};
+use sic_io::encoding_format::EncodingFormatDecider;
+use sic_io::{export, import};
 use sic_user_manual::user_manual_printer::UserManualPrinter;
 
 use crate::app::custom_config::manual_arg;
+use crate::app::license_display::LicenseDisplayProcessor;
 
 const LICENSE_SELF: &str = include_str!("../../LICENSE");
 const LICENSE_DEPS: &str = include_str!("../../thanks/dependency_licenses.txt");

--- a/tests/cli_convert.rs
+++ b/tests/cli_convert.rs
@@ -1,7 +1,7 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use sic_core::combostew::image;
+use sic_core::image;
 
 use sic_lib::app::cli::{cli as get_app, sic_config};
 use sic_lib::app::run_mode::run;


### PR DESCRIPTION
* combostew: io => `sic_io`
* combostew: config => `sic_config`
* combostew: processor:
  * license_display => `sic_lib`
  * mod_test_includes => `sic_testing`
  * conversion => `sic_io`
  * encoding_format => `sic_io`

Additionally, ProcessWithConfig was not ported over.
Modules which depended on it were slightly changed to accommodate for
this change.

This change set does not included further refactorings like
removing unnecessary dependencies on the sic_config crate.

closes #129 