### PR TITLE
Fix pest grammar, which accepted blur with uint instead of fp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The available image operations are:
 
 |operations|syntax|available (from version)|description|
 |---|---|---|---|
-|blur               | `blur <uint>`                         | Yes (0.5.0) 	    | Performs a Gaussian blur on the image ([more info](https://docs.rs/image/0.19.0/image/imageops/fn.blur.html)). |
+|blur               | `blur <fp>`                           | Yes (0.5.0) 	    | Performs a Gaussian blur on the image ([more info](https://docs.rs/image/0.19.0/image/imageops/fn.blur.html)). An argument below `0.0`, will use `1.0` instead. |
 |brighten           | `brighten <int>`                      | Yes (0.7.0) 	    | |
 |contrast           | `contrast <fp>`                       | Yes (0.7.0) 	    | |
 |crop               | `crop <int> <int> <int> <int>`        | Yes (0.9.0)       | Syntax: `crop <lx> <ly> <rx> <ry>`, where `lx` is top left corner x coordinate starting at 0, `ly` is the top left corner y coordinate starting at 0, `rx` is the  bottom right corner x coordinate and `ry` is the bottom right corner y coordinate. `rx` and `ry` should be larger than `lx` and `ly` respectively. |
@@ -81,9 +81,9 @@ For some operations, their behaviour can be (slightly) changed by choosing and e
 
 _legend_:
 ```
-<uint> means any 32 bit unsigned integer is required as parameter input.
-<int> means any 32 bit signed integer is required as parameter input.
-<fp> means any 32 bit floating point number is required as parameter input.
+<uint> means any 32 bit unsigned integer is required as argument.
+<int> means any 32 bit signed integer is required as argument.
+<fp> means any 32 bit floating point number is required as argument.
 <value> means a pre defined value. 
 <args9> means `<fp> <fp> <fp> <fp> <fp> <fp> <fp> <fp> <fp>`.
 ```
@@ -94,6 +94,7 @@ For each example: each of the lines are valid syntactically and the full example
 **blur** example:
 ```
 blur 10;
+blur 
 ```
 
 **brighten** example:

--- a/docs/cli_help_script.txt
+++ b/docs/cli_help_script.txt
@@ -25,9 +25,9 @@ Supported operations:
 
 table legend:
 
-<uint> means any 32 bit unsigned integer is required as parameter input.
-<int> means any 32 bit signed integer is required as parameter input.
-<fp> means any 32 bit floating point number is required as parameter input.
+<uint> means any 32 bit unsigned integer is required as argument.
+<int> means any 32 bit signed integer is required as argument.
+<fp> means any 32 bit floating point number is required as argument.
 <fp9x> means `<fp> <fp> <fp> <fp> <fp> <fp> <fp> <fp> <fp>`.
 
 

--- a/docs/cli_help_script_blur.txt
+++ b/docs/cli_help_script_blur.txt
@@ -7,13 +7,16 @@ Performs a Gaussian blur on the image.
 
 Syntax:
 -------
-`blur <uint>`
+`blur <fp>`
 
-where <uint> means: any 32 bit unsigned integer is required as parameter input.
+where <fp> means: any 32 bit floating point number is required as argument.
+
+All negative arguments (argument below 0.0), uses 1.0 instead as amount of the measure of how much to blur by.
 
 Usage example:
 --------------
 `sic input.png output.png --apply-operations "blur 10;"`
+`sic input.png output.png --apply-operations "blur 1.5;"`
 
 See also:
 ---------

--- a/docs/cli_help_script_brighten.txt
+++ b/docs/cli_help_script_brighten.txt
@@ -9,7 +9,7 @@ Syntax:
 -------
 `brighten <int>`
 
-where <int> means: any 32 bit signed integer is required as parameter input.
+where <int> means: any 32 bit signed integer is required as argument.
 
 A positive value for <int> means the brightness will be increased, and a negative value for <int> means the brightness will be decreased.
 

--- a/docs/cli_help_script_contrast.txt
+++ b/docs/cli_help_script_contrast.txt
@@ -9,7 +9,7 @@ Syntax:
 -------
 `contrast <fp>`
 
-where <fp> means: any 32 bit floating point number is required as parameter input.
+where <fp> means: any 32 bit floating point number is required as argument.
 
 A positive value for <int> means the contrast will be increased, and a negative value for <int> means the contrast will be decreased.
 

--- a/docs/cli_help_script_filter3x3.txt
+++ b/docs/cli_help_script_filter3x3.txt
@@ -10,7 +10,7 @@ Syntax:
 `filter3x3 <args9>`
 
 <args9> means `<fp> <fp> <fp> | <fp> <fp> <fp> | <fp> <fp> <fp>` where the `|` separator is optional. If the separator is used, white space should surround the separator. The separators can only be used like in the example, so one separator after each of the first two triplets.
-and <fp> means: any 32 bit floating point number is required as parameter input
+and <fp> means: any 32 bit floating point number is required as argument.
 
 Usage example:
 --------------

--- a/docs/cli_help_script_huerotate.txt
+++ b/docs/cli_help_script_huerotate.txt
@@ -9,7 +9,7 @@ Syntax:
 -------
 `huerotate <int>`
 
-where <int> means: any 32 bit signed integer is required as parameter input.
+where <int> means: any 32 bit signed integer is required as argument.
 
 The provided <int> argument decides how much degrees the hue will be rotated.
 The actual rotation will be <int>%360 degrees.

--- a/docs/cli_help_script_resize.txt
+++ b/docs/cli_help_script_resize.txt
@@ -12,7 +12,7 @@ Syntax:
 -------
 `resize <uint> <uint>`
 
-where <uint> means: any 32 bit unsigned integer is required as parameter input.
+where <uint> means: any 32 bit unsigned integer is required as argument.
 
 The first <uint> represents the projected width of the output image and the second <uint> argument represents the projected height of the output image.
 

--- a/docs/cli_help_script_unsharpen.txt
+++ b/docs/cli_help_script_unsharpen.txt
@@ -9,8 +9,8 @@ Syntax:
 -------
 `unsharpen <fp> <int>`
 
-where <fp> means: any 32 bit floating point number is required as parameter input.
-and <int> means: any 32 bit signed integer is required as parameter input.
+where <fp> means: any 32 bit floating point number is required as argument.
+and <int> means: any 32 bit signed integer is required as argument.
 
 The first argument (<fp>) decides how much the image is blurred, and the second argument (<int>) defines the threshold of how much the image will be sharpened.
 

--- a/sic_parser/src/grammar.pest
+++ b/sic_parser/src/grammar.pest
@@ -12,7 +12,7 @@ triplet_fp3 = _{ fp ~ WHITESPACE ~ fp ~ WHITESPACE ~ fp }
 f3x3_args_sep = _{ triplet_fp3 ~ triplet_sep ~ triplet_fp3 ~ triplet_sep ~ triplet_fp3 }
 f3x3_args_no_sep = _{ triplet_fp3 ~ WHITESPACE ~ triplet_fp3 ~ WHITESPACE ~ triplet_fp3 }
 
-blur = ${ ^"blur" ~ WHITESPACE ~ uint}
+blur = ${ ^"blur" ~ WHITESPACE ~ fp }
 brighten = ${ ^"brighten" ~ WHITESPACE ~ int }
 contrast = ${ ^"contrast" ~ WHITESPACE ~ fp }
 crop = ${ ^"crop" ~ WHITESPACE ~ uint ~ WHITESPACE ~ uint ~ WHITESPACE ~ uint ~ WHITESPACE ~ uint }

--- a/sic_parser/src/rule_parser.rs
+++ b/sic_parser/src/rule_parser.rs
@@ -423,13 +423,41 @@ mod tests {
     }
 
     #[test]
-    fn test_blur_single_stmt_parse_correct() {
+    fn test_blur_with_int_accept() {
         let pairs = SICParser::parse(Rule::main, "blur 15;")
             .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
         assert_eq!(
             Ok(vec![Statement::Operation(Operation::Blur(15.0))]),
             parse_image_operations(pairs)
         );
+    }
+
+    // related issue: https://github.com/foresterre/sic/issues/130
+    #[test]
+    fn test_blur_with_fp_accept() {
+        let pairs = SICParser::parse(Rule::main, "blur 15.0;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+        assert_eq!(
+            Ok(vec![Statement::Operation(Operation::Blur(15.0))]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    fn test_blur_with_fp_neg_accept() {
+        let pairs = SICParser::parse(Rule::main, "blur -15.0;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
+        assert_eq!(
+            Ok(vec![Statement::Operation(Operation::Blur(-15.0))]),
+            parse_image_operations(pairs)
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_blur_with_fp_reject() {
+        SICParser::parse(Rule::main, "blur 15.;")
+            .unwrap_or_else(|e| panic!("Unable to parse sic image operations script: {:?}", e));
     }
 
     #[test]


### PR DESCRIPTION
* Accept floating point numbers for blur, instead of uint.
* The lowered code did work with f32 already.

closes #130 