### PR TITLE
Reduce executable size: compress the included dependency licenses text. 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,11 @@ version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "cc"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +166,17 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "flate2"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +251,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "memoffset"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "miniz-sys"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "adler32 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "nodrop"
@@ -431,13 +464,14 @@ name = "sic"
 version = "0.9.0"
 dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "sic_core 0.1.0",
  "sic_image_engine 0.1.0",
  "sic_io 0.2.0",
  "sic_parser 0.1.0",
  "sic_testing 0.1.0",
  "sic_user_manual 0.1.0",
- "snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -479,15 +513,6 @@ version = "0.1.0"
 [[package]]
 name = "sic_user_manual"
 version = "0.1.0"
-
-[[package]]
-name = "snap"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "strsim"
@@ -589,6 +614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
+"checksum cc 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "b548a4ee81fccb95919d4e22cfea83c7693ebfd78f0495493178db20b3139da7"
 "checksum cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum color_quant 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
@@ -600,6 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "05f47366984d3ad862010e22c7ce81a7dbcaebbdfb37241a620f8b6596ee135c"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum flate2 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "2adaffba6388640136149e18ed080b77a78611c1e1d6de75aedcdf78df5d4682"
 "checksum generic-array 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c0f28c2f5bfb5960175af447a2da7c18900693738343dc896ffbcabd9839592"
 "checksum gif 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "86c2f2b597d6e05c86ee5947b2223bda468fe8dad3e88e2a6520869322aaf568"
 "checksum image 0.22.1 (registry+https://github.com/rust-lang/crates.io-index)" = "663a975007e0b49903e2e8ac0db2c432c465855f2d65f17883ba1476e85f0b42"
@@ -610,6 +637,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lzw 0.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7d947cbb889ed21c2a84be6ffbaebf5b4e0f4340638cba0444907e38b56be084"
 "checksum maplit 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08cbb6b4fef96b6d77bfc40ec491b1690c779e77b05cd9f07f787ed376fd4c43"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum miniz-sys 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9e3ae51cea1576ceba0dde3d484d30e6e5b86dee0b2d412fe3a16a15c98202"
+"checksum miniz_oxide 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7108aff85b876d06f22503dcce091e29f76733b2bfdd91eebce81f5e68203a10"
 "checksum nodrop 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)" = "2f9667ddcc6cc8a43afc9b7917599d7216aa09c463919ea32c59ed6cac8bc945"
 "checksum num-derive 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "eafd0b45c5537c3ba526f79d3e75120036502bebacbb3f3220914067ce39dbf2"
 "checksum num-integer 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "b85e541ef8255f6cf42bbfe4ef361305c6c135d10919ecc26126c4e5ae94bc09"
@@ -633,7 +662,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
-"checksum snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95d697d63d44ad8b78b8d235bf85b34022a78af292c8918527c5f0cffdde7f43"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "sic_parser 0.1.0",
  "sic_testing 0.1.0",
  "sic_user_manual 0.1.0",
+ "snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -478,6 +479,15 @@ version = "0.1.0"
 [[package]]
 name = "sic_user_manual"
 version = "0.1.0"
+
+[[package]]
+name = "snap"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"
@@ -623,6 +633,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
+"checksum snap 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "95d697d63d44ad8b78b8d235bf85b34022a78af292c8918527c5f0cffdde7f43"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
 "checksum termion 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dde0593aeb8d47accea5392b39350015b5eccb12c0d98044d856983d89548dea"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ sic_parser = { path = "sic_parser" }
 sic_user_manual  = { path = "sic_user_manual" }
 
 clap = "2.32.0"
-snap = "0.2.5"
+inflate = "0.4.5"
 
 [dev-dependencies]
 sic_testing = { path = "sic_testing" }
 
 [build-dependencies]
-snap = "0.2.5 "
+flate2 = "1.0.11"
 
 [[bin]]
 name = "sic"
@@ -55,6 +55,7 @@ path = "src/lib.rs"
 [features]
 output-test-images = []
 
-
 [profile.release]
 panic = "abort"
+#lto = true
+#codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,15 +29,20 @@ members = [
 ]
 
 [dependencies]
-clap = "2.32.0"
 sic_core = { path = "sic_core" }
 sic_image_engine = { path = "sic_image_engine" }
 sic_io  = { path = "sic_io" }
 sic_parser = { path = "sic_parser" }
 sic_user_manual  = { path = "sic_user_manual" }
 
+clap = "2.32.0"
+snap = "0.2.5"
+
 [dev-dependencies]
 sic_testing = { path = "sic_testing" }
+
+[build-dependencies]
+snap = "0.2.5 "
 
 [[bin]]
 name = "sic"

--- a/build.rs
+++ b/build.rs
@@ -1,3 +1,5 @@
+use flate2::write::DeflateEncoder;
+use flate2::Compression;
 use std::env;
 use std::fs::File;
 use std::io::Write;
@@ -15,8 +17,8 @@ fn main() {
         "/dependency_licenses.txt"
     ));
 
-    let mut writer = snap::Writer::new(file);
-    writer
+    let mut encoder = DeflateEncoder::new(file, Compression::default());
+    encoder
         .write_all(text)
-        .expect("unable to write dependency licenses as compressed file.");
+        .expect("Unable to compress dep licenses tet");
 }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,22 @@
+use std::env;
+use std::fs::File;
+use std::io::Write;
+use std::path::Path;
+
+fn main() {
+    // Compress the thanks/dependency_licenses.txt file, because it's huge.
+    let folder = env::var("OUT_DIR").expect("OUT_DIR not set");
+    let path = Path::new(&folder).join("compressed_dep_licenses");
+    let file = File::create(&path).unwrap();
+
+    let text = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/thanks",
+        "/dependency_licenses.txt"
+    ));
+
+    let mut writer = snap::Writer::new(file);
+    writer
+        .write_all(text)
+        .expect("unable to write dependency licenses as compressed file.");
+}

--- a/src/app/license_display.rs
+++ b/src/app/license_display.rs
@@ -1,8 +1,8 @@
 use crate::app::config::SelectedLicenses;
-use std::io::Read;
+use inflate::inflate_bytes;
 
 const LICENSE_SELF: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/LICENSE",));
-const LICENSE_DEPS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/compressed_dep_licenses",));
+const LICENSE_DEPS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/compressed_dep_licenses"));
 
 pub(crate) trait PrintTextFor {
     fn print(&self) -> Result<(), String>;
@@ -17,17 +17,8 @@ impl PrintTextFor for SelectedLicenses {
         }
 
         fn print_for_dependencies() -> Result<(), String> {
-            // based on the size the reader gets as input as of 2019/08/22.
-            // size was: 579028, rounded up (power of two): 1048576 (about one MB!)
-            const SIZE: usize = 579028;
-
-            let mut reader = snap::Reader::new(LICENSE_DEPS);
-            let mut vec: Vec<u8> = Vec::with_capacity(SIZE);
-            let _ = reader
-                .read_to_end(&mut vec)
-                .map_err(|err| format!("Unable to uncompress license text: {}", err))?;
-
-            let text = std::str::from_utf8(&vec).map_err(|err| err.to_string())?;
+            let inflated = inflate_bytes(LICENSE_DEPS)?;
+            let text = std::str::from_utf8(&inflated).map_err(|err| err.to_string())?;
 
             println!("{}", text);
 

--- a/src/app/license_display.rs
+++ b/src/app/license_display.rs
@@ -1,48 +1,45 @@
-use std::process;
+use crate::app::config::SelectedLicenses;
+use std::io::Read;
 
-use crate::app::config::{Config, SelectedLicenses};
+const LICENSE_SELF: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/LICENSE",));
+const LICENSE_DEPS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/compressed_dep_licenses",));
 
-#[derive(Debug, Default)]
-pub struct LicenseDisplayProcessor<'a> {
-    self_license: &'a str,
-    dependency_licenses: &'a str,
+pub(crate) trait PrintTextFor {
+    fn print(&self) -> Result<(), String>;
 }
 
-impl<'a> LicenseDisplayProcessor<'a> {
-    pub fn new(self_license: &'a str, dependency_licenses: &'a str) -> LicenseDisplayProcessor<'a> {
-        LicenseDisplayProcessor {
-            self_license,
-            dependency_licenses,
+impl PrintTextFor for SelectedLicenses {
+    fn print(&self) -> Result<(), String> {
+        fn print_for_this_software() -> Result<(), String> {
+            println!("sic image tools license:\n\n{}\n\n", LICENSE_SELF);
+
+            Ok(())
         }
-    }
-}
 
-impl<'a> LicenseDisplayProcessor<'a> {
-    fn print_licenses(&self, requested_texts: SelectedLicenses, tool_name: &str) {
-        let print_for_this_software = || {
-            println!(
-                "{} image tools license:\n\n{}\n\n",
-                tool_name, &self.self_license
-            );
-        };
+        fn print_for_dependencies() -> Result<(), String> {
+            // based on the size the reader gets as input as of 2019/08/22.
+            // size was: 579028, rounded up (power of two): 1048576 (about one MB!)
+            const SIZE: usize = 579028;
 
-        let print_for_dependencies = || println!("{}", &self.dependency_licenses);
+            let mut reader = snap::Reader::new(LICENSE_DEPS);
+            let mut vec: Vec<u8> = Vec::with_capacity(SIZE);
+            let _ = reader
+                .read_to_end(&mut vec)
+                .map_err(|err| format!("Unable to uncompress license text: {}", err))?;
 
-        match requested_texts {
+            let text = std::str::from_utf8(&vec).map_err(|err| err.to_string())?;
+
+            println!("{}", text);
+
+            Ok(())
+        }
+
+        match self {
             SelectedLicenses::ThisSoftware => print_for_this_software(),
             SelectedLicenses::Dependencies => print_for_dependencies(),
             SelectedLicenses::ThisSoftwarePlusDependencies => {
-                print_for_this_software();
-                print_for_dependencies();
+                print_for_this_software().and_then(|_| print_for_dependencies())
             }
-        };
-    }
-
-    pub fn process(&self, config: &Config) {
-        if let Some(selection) = config.show_license_text_of {
-            self.print_licenses(selection, &config.tool_name);
-        } else {
-            process::exit(0)
         }
     }
 }

--- a/src/app/run_mode.rs
+++ b/src/app/run_mode.rs
@@ -13,10 +13,7 @@ use sic_io::{export, import, ExportMethod, ExportSettings};
 use sic_user_manual::user_manual_printer::UserManualPrinter;
 
 use crate::app::config::Config;
-use crate::app::license_display::LicenseDisplayProcessor;
-
-const LICENSE_SELF: &str = include_str!("../../LICENSE");
-const LICENSE_DEPS: &str = include_str!("../../thanks/dependency_licenses.txt");
+use crate::app::license_display::PrintTextFor;
 
 /// The run function runs the sic application, taking the matches found by Clap.
 /// This function is separated from the main() function so that it can be used more easily in test cases.
@@ -89,11 +86,10 @@ fn determine_export_method<P: AsRef<Path>>(
 }
 
 pub fn run_display_licenses(config: &Config) -> Result<(), String> {
-    let license_display_processor = LicenseDisplayProcessor::new(LICENSE_SELF, LICENSE_DEPS);
-
-    license_display_processor.process(&config);
-
-    Ok(())
+    config
+        .show_license_text_of
+        .ok_or_else(|| "Unable to display license texts".to_string())
+        .and_then(|license_text| license_text.print())
 }
 
 pub fn run_display_help(config: &Config) -> Result<(), String> {


### PR DESCRIPTION
The current executable size is quite big. One thing which increases the executable size is the DEP_LICENSES file, which is distributed with every build. Some licenses of deendencies we use require this and for others: it is only fair to attribute these authors.  

This file contains huge amounts of duplication (because many dependencies use
the same licenses), thus is likely to have a good compression ratio.

This PR compresses the DEP_LICENSES file on compile time. Then (still on compile time) the resulting compressed bytes are included in the executable. At runtime, if `--dep-licenses` is used, we uncompress the license text and show it. 

If this doesn't reduce the binary enough (but how much is enough?), another option might be to provide the release
binaries within a zip file, which also contains the dependency licenses
text separately.

I currently do not intend to compile for smaller executable sizes over speed optimizations or to go to extremes to reduce the file size.

There are also additional steps, such as stripping symbol information, which
will provide additional gains in reduced file size (stripping release build actually gives huge gains, which is something I should definitely do).

**text only compressed**
```
566K dependency_licenses.txt
89K dependency_licenses.txt.sz
15K dependency_licenses.txt.gz
```

The current implementation uses Snappy compression, since the library was very accessible. However, other compression methods might have even bigger reductions (such as gzip).
Before this PR will be merged, I'd like to try out a few additional compression libraries.

Sizes with `cargo --release`:

|  |  |  | size (bytes) | stripped (bytes) |  |  |
|---------------------|-------------------|---------|----------------|------------------|-------------------|------------------------|
| Encoder crate | Compression level | format | `ls -l` | `ls -l` | (decoder) | Improvement? |
| **Original (NONE)** | N/A | N/A | 5241912 (5.2M) | 2656624 (2.7M) |  |  |
| snap = "0.2.5" |  | Snappy |  | 2197872 (2.2M) | snap = "0.2.5" | :white_check_mark: |
| flate2 = "1.0.11" | 6 (default) | DEFLATE | 4681344 | 2095472 (2.1M) | inflate = "0.4.5" | :heavy_check_mark: |
|  | 9 (max) | DEFLATE | 4681344 | 2095472 (2.1M) |  | (nothing over level=6) |
| zopfli = "0.4.0" | iter=15 (default) | DEFLATE | 4677240 | 2091376 (2.1M) | inflate = "0.4.5" | compile time ~20x? |
| flate2 = "1.0.11" | 6 (default) | gz | 4721968 | 2128240 (2.1M) | flate2 = "1.0.11" |  |
| flate2 = "1.0.11" | 6 (default) | zlib | 4707816 | 2115952 (2.1M) | flate2 = "1.0.11" |  |
| gzip on unix, else flate2  | default  | gz  | 4717872  | 2124144 (2.1M) |  |  |


Possible compression crates:

* https://crates.io/crates/libflate
* https://crates.io/crates/deflate
* https://crates.io/crates/miniz_oxide
* https://crates.io/crates/zopfli (encoding only; possibly to slow for compiling?)
* https://crates.io/crates/inflate (only decoding: would need an encoder for the build.rs; is only 18kb)
* https://crates.io/crates/zstd

**before:**
```
cargo bloat --release
Compiling ...
Analyzing target/release/sic

 File  .text    Size     Crate Name
 0.6%   2.0% 31.7KiB   inflate inflate::InflateStream::next_state
 0.6%   1.9% 29.5KiB     image image::webp::vp8::VP8Decoder<R>::decode_frame
 0.5%   1.7% 27.0KiB      clap clap::app::parser::Parser::get_matches_with
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.3%   0.9% 14.3KiB      clap clap::app::help::Help::write_arg
 0.3%   0.9% 14.3KiB       png png::decoder::stream::StreamingDecoder::update
 0.3%   0.9% 13.4KiB      clap clap::app::usage::get_required_usage_from
 0.3%   0.9% 13.4KiB      clap clap::app::validator::Validator::validate_matched_args
 0.2%   0.8% 12.2KiB     image image::dynimage::open_impl
 0.2%   0.7% 11.7KiB      clap clap::app::help::Help::_write_parser_help
 0.2%   0.7% 11.5KiB     image tiff::decoder::Decoder<R>::new
 0.2%   0.7% 11.3KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.7% 10.5KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.6% 10.1KiB      clap clap::app::validator::Validator::validate
 0.2%   0.6%  9.5KiB      clap clap::app::usage::create_help_usage
 0.2%   0.6%  9.0KiB     image image::dynimage::load_from_memory
 0.2%   0.6%  8.8KiB [Unknown] read_line_info
 0.2%   0.5%  8.4KiB   sic_lib sic_lib::app::cli::cli
 0.1%   0.5%  7.6KiB     image image::webp::vp8::predict_4x4
25.1%  81.3%  1.3MiB           And 2945 smaller methods. Use -n N to show more.
30.9% 100.0%  1.5MiB           .text section size, the file size is 5.0MiB
```
stripped: `2.6M (2656624) target/release/sic`

**after (Snappy):**
```
cargo bloat --release
Compiling ...
Analyzing target/release/sic

 File  .text    Size     Crate Name
 0.7%   2.0% 31.7KiB   inflate inflate::InflateStream::next_state
 0.6%   1.8% 29.5KiB     image image::webp::vp8::VP8Decoder<R>::decode_frame
 0.6%   1.7% 27.0KiB      clap clap::app::parser::Parser::get_matches_with
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.3%   0.9% 14.3KiB      clap clap::app::help::Help::write_arg
 0.3%   0.9% 14.3KiB       png png::decoder::stream::StreamingDecoder::update
 0.3%   0.8% 13.4KiB      clap clap::app::usage::get_required_usage_from
 0.3%   0.8% 13.4KiB      clap clap::app::validator::Validator::validate_matched_args
 0.3%   0.8% 12.2KiB     image image::dynimage::open_impl
 0.2%   0.7% 11.7KiB      clap clap::app::help::Help::_write_parser_help
 0.2%   0.7% 11.5KiB     image tiff::decoder::Decoder<R>::new
 0.2%   0.7% 11.3KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.7% 10.5KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.6% 10.1KiB      clap clap::app::validator::Validator::validate
 0.2%   0.6%  9.5KiB      clap clap::app::usage::create_help_usage
 0.2%   0.6%  9.0KiB     image image::dynimage::load_from_memory
 0.2%   0.5%  8.8KiB [Unknown] read_line_info
 0.2%   0.5%  8.4KiB   sic_lib sic_lib::app::cli::cli
 0.2%   0.5%  7.6KiB     image image::webp::vp8::predict_4x4
27.8%  81.5%  1.3MiB           And 2997 smaller methods. Use -n N to show more.
34.1% 100.0%  1.6MiB           .text section size, the file size is 4.6MiB

```

stripped: `2.1M (2197872) target/release/sic`

**After (deflate2, DEFLATE)**:

```
 cargo bloat --release
Compiling ...
Analyzing target/release/sic

 File  .text    Size     Crate Name
 0.7%   2.0% 31.7KiB   inflate inflate::InflateStream::next_state
 0.6%   1.9% 29.5KiB     image image::webp::vp8::VP8Decoder<R>::decode_frame
 0.6%   1.7% 27.0KiB      clap clap::app::parser::Parser::get_matches_with
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.3%   0.9% 14.3KiB      clap clap::app::help::Help::write_arg
 0.3%   0.9% 14.3KiB       png png::decoder::stream::StreamingDecoder::update
 0.3%   0.8% 13.4KiB      clap clap::app::usage::get_required_usage_from
 0.3%   0.8% 13.4KiB      clap clap::app::validator::Validator::validate_matched_args
 0.3%   0.8% 12.2KiB     image image::dynimage::open_impl
 0.3%   0.7% 11.7KiB      clap clap::app::help::Help::_write_parser_help
 0.3%   0.7% 11.5KiB     image tiff::decoder::Decoder<R>::new
 0.2%   0.7% 11.3KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.7% 10.5KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.6% 10.1KiB      clap clap::app::validator::Validator::validate
 0.2%   0.6%  9.5KiB      clap clap::app::usage::create_help_usage
 0.2%   0.6%  9.0KiB     image image::dynimage::load_from_memory
 0.2%   0.6%  8.8KiB [Unknown] read_line_info
 0.2%   0.5%  7.6KiB     image image::webp::vp8::predict_4x4
 0.2%   0.5%  7.5KiB     image tiff::decoder::Decoder<R>::new
28.2%  81.4%  1.3MiB           And 2949 smaller methods. Use -n N to show more.
34.6% 100.0%  1.5MiB           .text section size, the file size is 4.5MiB
```

**after (deflate2, gzip)**:
```
 cargo bloat --release   
Compiling ...
Analyzing target/release/sic

 File  .text    Size     Crate Name
 0.7%   2.0% 31.7KiB   inflate inflate::InflateStream::next_state
 0.6%   1.8% 29.5KiB     image image::webp::vp8::VP8Decoder<R>::decode_frame
 0.6%   1.7% 27.0KiB      clap clap::app::parser::Parser::get_matches_with
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.4%   1.3% 20.5KiB     image jpeg_decoder::decoder::Decoder<R>::decode_internal
 0.3%   0.9% 14.3KiB      clap clap::app::help::Help::write_arg
 0.3%   0.9% 14.3KiB       png png::decoder::stream::StreamingDecoder::update
 0.3%   0.8% 13.4KiB      clap clap::app::usage::get_required_usage_from
 0.3%   0.8% 13.4KiB      clap clap::app::validator::Validator::validate_matched_args
 0.3%   0.8% 12.2KiB     image image::dynimage::open_impl
 0.3%   0.7% 11.7KiB      clap clap::app::help::Help::_write_parser_help
 0.2%   0.7% 11.5KiB     image tiff::decoder::Decoder<R>::new
 0.2%   0.7% 11.3KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.7% 10.8KiB miniz_sys tinfl_decompress
 0.2%   0.7% 10.5KiB     image tiff::decoder::ifd::Entry::val
 0.2%   0.6% 10.1KiB      clap clap::app::validator::Validator::validate
 0.2%   0.6%  9.5KiB      clap clap::app::usage::create_help_usage
 0.2%   0.6%  9.0KiB     image image::dynimage::load_from_memory
 0.2%   0.5%  8.8KiB [Unknown] read_line_info
 0.2%   0.5%  7.6KiB     image image::webp::vp8::predict_4x4
28.3%  81.5%  1.3MiB           And 3004 smaller methods. Use -n N to show more.
34.8% 100.0%  1.6MiB           .text section size, the file size is 4.5MiB

```