### PR TITLE
change type signature of ignite fn  statements parameter

### DIFF
--- a/sic_image_engine/src/engine.rs
+++ b/sic_image_engine/src/engine.rs
@@ -96,7 +96,7 @@ impl ImageEngine {
         }
     }
 
-    pub fn ignite(&mut self, statements: &Program) -> Result<&DynamicImage, Box<dyn Error>> {
+    pub fn ignite(&mut self, statements: &[Statement]) -> Result<&DynamicImage, Box<dyn Error>> {
         for stmt in statements {
             match self.process_statement(stmt) {
                 Ok(_) => continue,


### PR DESCRIPTION
Resolve warning on taking reference of vector instead of slice
fixes #187 