### PR TITLE
Add a version in addition to the path for dependencies of components.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ members = [
 ]
 
 [dependencies]
-sic_core = { path = "components/sic_core" }
-sic_image_engine = { path = "components/sic_image_engine" }
-sic_io  = { path = "components/sic_io" }
-sic_parser = { path = "components/sic_parser" }
+sic_core = { path = "components/sic_core", version = "0.10" }
+sic_image_engine = { path = "components/sic_image_engine", version = "0.10" }
+sic_io  = { path = "components/sic_io", version = "0.10" }
+sic_parser = { path = "components/sic_parser", version = "0.10" }
 
 atty = "0.2.13"
 clap = "2.32.0"

--- a/components/sic_image_engine/Cargo.toml
+++ b/components/sic_image_engine/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "../../LICENSE"
 repository = "https://github.com/foresterre/sic"
 
 [dependencies]
-sic_core = { path = "../sic_core" }
+sic_core = { path = "../sic_core", version = "0.10" }
 
 strum = "0.16.0"
 strum_macros = "0.16.0"

--- a/components/sic_io/Cargo.toml
+++ b/components/sic_io/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "../../LICENSE"
 repository = "https://github.com/foresterre/sic"
 
 [dependencies]
-sic_core = { path = "../sic_core" }
+sic_core = { path = "../sic_core", version = "0.10" }
 
 [dev-dependencies]
 sic_testing = { path = "../sic_testing" }

--- a/components/sic_parser/Cargo.toml
+++ b/components/sic_parser/Cargo.toml
@@ -8,7 +8,8 @@ license-file = "../../LICENSE"
 repository = "https://github.com/foresterre/sic"
 
 [dependencies]
-sic_core = { path = "../sic_core" }
-sic_image_engine = { path = "../sic_image_engine" }
+sic_core = { path = "../sic_core", version = "0.10" }
+sic_image_engine = { path = "../sic_image_engine", version = "0.10" }
+
 pest = "2.1.2"
 pest_derive = "2.0.1"

--- a/components/sic_testing/Cargo.toml
+++ b/components/sic_testing/Cargo.toml
@@ -8,4 +8,4 @@ license-file = "../../LICENSE"
 repository = "https://github.com/foresterre/sic"
 
 [dependencies]
-sic_core = { path = "../sic_core"}
+sic_core = { path = "../sic_core", version = "0.10" }


### PR DESCRIPTION
This way, we can use the in development version locally,
while not having to replace the path with a version number when
publishing the crate.