### PR TITLE
Replace custom, String based and casted error handling with anyhow and thiserror crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,9 +122,10 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -347,9 +353,9 @@ name = "parameterized-macro"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -376,9 +382,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "pest 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest_meta 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -412,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -431,7 +437,7 @@ name = "quote"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -450,7 +456,7 @@ version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -502,6 +508,7 @@ dependencies = [
 name = "sic"
 version = "0.10.1"
 dependencies = [
+ "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.13 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -528,6 +535,7 @@ dependencies = [
  "sic_testing 0.10.0",
  "strum 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -536,6 +544,7 @@ version = "0.10.0"
 dependencies = [
  "sic_core 0.10.0",
  "sic_testing 0.10.0",
+ "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -547,6 +556,7 @@ dependencies = [
  "pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sic_core 0.10.0",
  "sic_image_engine 0.10.0",
+ "thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -572,9 +582,9 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -589,10 +599,10 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.5"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -603,6 +613,24 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -673,6 +701,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)" = "7825f6833612eb2414095684fcf6c635becf3ce97fe48cf6421321e93bfbd53c"
 "checksum atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
@@ -686,7 +715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum crossbeam-deque 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3aa945d63861bfe624b55d153a39684da1e8c0bc8fba932f7ee3a3c16cea3ca"
 "checksum crossbeam-epoch 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5064ebdbf05ce3cb95e45c8b086f72263f4166b29b97f6baff7ef7fe047b55ac"
-"checksum crossbeam-queue 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dfd6515864a82d2f877b42813d4553292c6659498c9a2aa31bab5a15243c2700"
+"checksum crossbeam-queue 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c695eeca1e7173472a32221542ae469b3e9aac3a4fc81f7696bcad82029493db"
 "checksum crossbeam-utils 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce446db02cdc3165b94ae73111e570793400d0794e46125cc4056c81cbb039f4"
 "checksum deflate 0.7.20 (registry+https://github.com/rust-lang/crates.io-index)" = "707b6a7b384888a70c8d2e8650b3e60170dfc6a67bb4aa67b6dfca57af4bedb4"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
@@ -721,7 +750,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pest_meta 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "df43fd99896fd72c485fe47542c7b500e4ac1e8700bf995544d1317a60ded547"
 "checksum png 0.15.2 (registry+https://github.com/rust-lang/crates.io-index)" = "247cb804bd7fc86d0c2b153d1374265e67945875720136ca8fe451f11c6aed52"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "175a40b9cf564ce9bf050654633dbf339978706b8ead1a907bb970b63185dd95"
+"checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum rayon 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "db6ce3297f9c85e16621bb8cca38a06779ffc31bb8184e1be4bed2be4678a098"
@@ -736,8 +765,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum strum 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "530efb820d53b712f4e347916c5e7ed20deb76a4f0457943b3182fb889b06d2c"
 "checksum strum_macros 0.17.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6e163a520367c465f59e0a61a23cfae3b10b6546d78b6f672a382be79f7110"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+"checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "6f357d1814b33bc2dc221243f8424104bfe72dbe911d5b71b3816a2dff1c977e"
+"checksum thiserror-impl 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)" = "eb2e25d25307eb8436894f727aba8f65d07adf02e5b35a13cebed48bd282bfef"
 "checksum tiff 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d7b7c2cfc4742bd8a32f2e614339dd8ce30dbcf676bb262bd63a2327bc5df57d"
 "checksum typenum 1.11.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6d2783fe2d6b8c1101136184eb41be8b1ad379e4657050b8aaff0c79ee7575f9"
 "checksum ucd-trie 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "8f00ed7be0c1ff1e24f46c3d2af4859f7e863672ba3a6e92e7cff702bf9f06c2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ sic_image_engine = { path = "components/sic_image_engine", version = "0.10" }
 sic_io  = { path = "components/sic_io", version = "0.10" }
 sic_parser = { path = "components/sic_parser", version = "0.10" }
 
+anyhow = "1.0"
 atty = "0.2.13"
 clap = "2.32.0"
 inflate = "0.4.5"

--- a/components/sic_image_engine/Cargo.toml
+++ b/components/sic_image_engine/Cargo.toml
@@ -12,6 +12,7 @@ sic_core = { path = "../sic_core", version = "0.10" }
 
 strum = "0.17.1"
 strum_macros = "0.17.1"
+thiserror = "1.0.6"
 
 [dev-dependencies]
 sic_testing = { path = "../sic_testing" }

--- a/components/sic_image_engine/src/errors.rs
+++ b/components/sic_image_engine/src/errors.rs
@@ -1,0 +1,10 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SicImageEngineError {
+    #[error("unable to crop; required top-left anchor < bottom-right anchor; note that (x=0,y=0) is the smallest top-left coordinate; [top-left anchor: (x={0}, y={1}), bottom-right anchor: (x={2}, y={3})]")]
+    CropInvalidSelection(u32, u32, u32, u32),
+
+    #[error("unable to crop; anchor coordinates should be within image bounds [image size: (x={0}, y={1}), top-left anchor: (x={2}, y={3}), bottom-right anchor: (x={4}, y={5})]")]
+    CropCoordinateOutOfBounds(u32, u32, u32, u32, u32, u32),
+}

--- a/components/sic_image_engine/src/errors.rs
+++ b/components/sic_image_engine/src/errors.rs
@@ -1,10 +1,13 @@
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, Eq, PartialEq)]
 pub enum SicImageEngineError {
     #[error("unable to crop; required top-left anchor < bottom-right anchor; note that (x=0,y=0) is the smallest top-left coordinate; [top-left anchor: (x={0}, y={1}), bottom-right anchor: (x={2}, y={3})]")]
     CropInvalidSelection(u32, u32, u32, u32),
 
     #[error("unable to crop; anchor coordinates should be within image bounds [image size: (x={0}, y={1}), top-left anchor: (x={2}, y={3}), bottom-right anchor: (x={4}, y={5})]")]
     CropCoordinateOutOfBounds(u32, u32, u32, u32, u32, u32),
+
+    #[error("filter type '{0}' not found")]
+    UnknownFilterType(String),
 }

--- a/components/sic_image_engine/src/lib.rs
+++ b/components/sic_image_engine/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate strum_macros;
 
 pub mod engine;
+pub mod errors;
 pub mod wrapper;
 
 #[derive(Debug, PartialEq, Clone)]

--- a/components/sic_image_engine/src/wrapper/filter_type.rs
+++ b/components/sic_image_engine/src/wrapper/filter_type.rs
@@ -1,7 +1,7 @@
-use std::error::Error;
 use std::fmt::{Debug, Formatter};
 use std::hash::Hash;
 
+use crate::errors::SicImageEngineError;
 use sic_core::image::FilterType;
 
 #[derive(Clone, Copy)]
@@ -50,14 +50,14 @@ impl From<FilterTypeWrap> for FilterType {
 }
 
 impl FilterTypeWrap {
-    pub fn try_from_str(val: &str) -> Result<FilterTypeWrap, Box<dyn Error>> {
+    pub fn try_from_str(val: &str) -> Result<FilterTypeWrap, SicImageEngineError> {
         match val.to_lowercase().as_str() {
             "catmullrom" | "cubic" => Ok(FilterTypeWrap::new(FilterType::CatmullRom)),
             "gaussian" => Ok(FilterTypeWrap::new(FilterType::Gaussian)),
             "lanczos3" => Ok(FilterTypeWrap::new(FilterType::Lanczos3)),
             "nearest" => Ok(FilterTypeWrap::new(FilterType::Nearest)),
             "triangle" => Ok(FilterTypeWrap::new(FilterType::Triangle)),
-            fail => Err(format!("No such sampling filter: {}", fail).into()),
+            fail => Err(SicImageEngineError::UnknownFilterType(fail.to_string())),
         }
     }
 }

--- a/components/sic_io/Cargo.toml
+++ b/components/sic_io/Cargo.toml
@@ -10,5 +10,7 @@ repository = "https://github.com/foresterre/sic"
 [dependencies]
 sic_core = { path = "../sic_core", version = "0.10" }
 
+thiserror = "1.0.6"
+
 [dev-dependencies]
 sic_testing = { path = "../sic_testing" }

--- a/components/sic_io/src/conversion.rs
+++ b/components/sic_io/src/conversion.rs
@@ -1,6 +1,6 @@
-use std::io::Write;
-
+use crate::errors::SicIoError;
 use sic_core::image;
+use std::io::Write;
 
 #[derive(Clone, Copy, Debug)]
 pub enum AutomaticColorTypeAdjustment {
@@ -30,7 +30,7 @@ impl<'a> ConversionWriter<'a> {
         writer: &mut W,
         output_format: image::ImageOutputFormat,
         color_type_adjustment: AutomaticColorTypeAdjustment,
-    ) -> Result<(), String> {
+    ) -> Result<(), SicIoError> {
         let color_processing = &ConversionWriter::pre_process_color_type(
             &self.image,
             &output_format,
@@ -83,10 +83,10 @@ impl<'a> ConversionWriter<'a> {
         writer: &mut W,
         buffer: &image::DynamicImage,
         format: image::ImageOutputFormat,
-    ) -> Result<(), String> {
+    ) -> Result<(), SicIoError> {
         buffer
             .write_to(writer, format)
-            .map_err(|err| err.to_string())
+            .map_err(|err| SicIoError::ImageError(err))
     }
 }
 

--- a/components/sic_io/src/errors.rs
+++ b/components/sic_io/src/errors.rs
@@ -1,0 +1,46 @@
+use sic_core::image::ImageError;
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SicIoError {
+    #[error("sic io error > {0}")]
+    ImageError(ImageError),
+
+    #[error("sic io error > {0}")]
+    Io(std::io::Error),
+
+    #[error("{0}")]
+    FormatError(FormatError),
+
+    #[error(
+        "An input image should be given by providing a path using the input argument or by \
+         piping an image to the stdin."
+    )]
+    NoInputImage,
+
+    #[error("Unable to extract frame {0} from the (animated) image. Reason given: {1}.")]
+    NoSuchFrame(usize, String),
+
+    #[error(
+        "No supported image output format was found. The following identifier was provided: {0}."
+    )]
+    UnknownImageIdentifier(String),
+
+    #[error(
+        "Unable to determine the image format from the file extension. The following path was given: {0}."
+    )]
+    UnableToDetermineImageFormatFromFileExtension(PathBuf),
+}
+
+#[derive(Debug, Error)]
+pub enum FormatError {
+    #[error("Unable to determine JPEG quality.")]
+    JPEGQualityLevelNotSet,
+
+    #[error("JPEG Quality should range between 1 and 100 (inclusive).")]
+    JPEGQualityLevelNotInRange,
+
+    #[error("Using PNM requires the sample encoding to be set.")]
+    PNMSamplingEncodingNotSet,
+}

--- a/components/sic_io/src/lib.rs
+++ b/components/sic_io/src/lib.rs
@@ -5,4 +5,5 @@ pub mod load;
 pub mod save;
 
 pub mod conversion;
+pub mod errors;
 pub mod format;

--- a/components/sic_io/src/load.rs
+++ b/components/sic_io/src/load.rs
@@ -88,21 +88,6 @@ impl Default for FrameIndex {
     }
 }
 
-//#[deprecated(since = "0.2.0", note = "Errors as Strings to be phased out.")]
-//impl From<ImportError> for String {
-//    fn from(error: ImportError) -> String {
-//        match error {
-//            ImportError::Io(err) => err.description().to_string(),
-//            ImportError::Image(err) => err.to_string(),
-//            ImportError::NoSuchFrame(which, reason) => format!(
-//                "Unable to extract frame {} from the (animated) image. Reason given: {}",
-//                which + 1,
-//                reason,
-//            ),
-//        }
-//    }
-//}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/components/sic_io/src/save.rs
+++ b/components/sic_io/src/save.rs
@@ -4,13 +4,14 @@ use std::path::Path;
 use sic_core::image;
 
 use crate::conversion::{AutomaticColorTypeAdjustment, ConversionWriter};
+use crate::errors::SicIoError;
 
 pub fn export<W: Write>(
     image: &image::DynamicImage,
     writer: &mut W,
     format: image::ImageOutputFormat,
     export_settings: ExportSettings,
-) -> Result<(), String> {
+) -> Result<(), SicIoError> {
     let conv = ConversionWriter::new(image);
     conv.write(writer, format, export_settings.adjust_color_type)
 }

--- a/components/sic_parser/Cargo.toml
+++ b/components/sic_parser/Cargo.toml
@@ -13,6 +13,7 @@ sic_image_engine = { path = "../sic_image_engine", version = "0.10" }
 
 pest = "2.1.2"
 pest_derive = "2.0.1"
+thiserror = "1.0.6"
 
 [dev-dependencies]
 parameterized = "0.1.1"

--- a/components/sic_parser/src/errors.rs
+++ b/components/sic_parser/src/errors.rs
@@ -1,0 +1,42 @@
+use sic_image_engine::errors::SicImageEngineError;
+use thiserror::Error;
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum SicParserError {
+    #[error("sic parser error > {0}")]
+    FilterTypeError(SicImageEngineError),
+
+    #[error("sic parser error > {0}")]
+    PestGrammarError(String),
+
+    #[error("{0}")]
+    OperationError(OperationParamError),
+
+    #[error("Parse failed: Operation doesn't exist")]
+    UnknownOperationError,
+
+    #[error("Unable to parse value '{0}'")]
+    ValueParsingError(String),
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum OperationParamError {
+    #[error(
+        "Unable to parse `set` environment command. Error: expected a single `set` inner element."
+    )]
+    SetEnvironment,
+
+    #[error("Unable to parse `set` environment command. Error on element: {0}")]
+    SetEnvironmentElement(String),
+
+    #[error("Unable to parse 'set resize_sampling_filter' option: {0}")]
+    SetResizeSamplingFilter(String),
+
+    #[error(
+        "Unable to parse `del` environment command. Error: expected a single `del` inner element."
+    )]
+    UnsetEnvironment,
+
+    #[error("Unable to parse `del` environment command. Error on element: {0}")]
+    UnsetEnvironmentElement(String),
+}

--- a/components/sic_parser/src/lib.rs
+++ b/components/sic_parser/src/lib.rs
@@ -3,9 +3,11 @@ extern crate pest_derive;
 
 use pest::Parser;
 
+use crate::errors::SicParserError;
 use crate::rule_parser::parse_image_operations;
 use sic_image_engine::engine::Instr;
 
+pub mod errors;
 pub mod rule_parser;
 pub mod value_parser;
 
@@ -15,11 +17,11 @@ const PARSER_RULE: Rule = Rule::main;
 #[grammar = "grammar.pest"]
 pub struct SICParser;
 
-pub fn parse_script(script: &str) -> Result<Vec<Instr>, String> {
+pub fn parse_script(script: &str) -> Result<Vec<Instr>, SicParserError> {
     let parsed_script = SICParser::parse(PARSER_RULE, script);
 
     parsed_script
-        .map_err(|err| format!("Unable to parse sic image operations script: {:?}", err))
+        .map_err(|err| SicParserError::PestGrammarError(err.to_string()))
         .and_then(parse_image_operations)
 }
 

--- a/src/app/config.rs
+++ b/src/app/config.rs
@@ -1,3 +1,4 @@
+use anyhow::bail;
 use sic_image_engine::engine::Instr;
 use sic_io::load::FrameIndex;
 
@@ -158,8 +159,8 @@ pub struct FormatEncodingSettings {
 
 /// Strictly speaking not necessary here since the responsible owners will validate the quality as well.
 /// However, by doing anyways it we can exit earlier.
-pub fn validate_jpeg_quality(quality: u8) -> Result<u8, String> {
-    fn within_range(v: u8) -> Result<u8, String> {
+pub fn validate_jpeg_quality(quality: u8) -> anyhow::Result<u8> {
+    fn within_range(v: u8) -> anyhow::Result<u8> {
         // Upper bound is exclusive with .. syntax.
         // When the `range_contains` feature will be stabilised Range.contains(&v)
         // should be used instead.
@@ -167,7 +168,7 @@ pub fn validate_jpeg_quality(quality: u8) -> Result<u8, String> {
         if ALLOWED_RANGE.contains(&v) {
             Ok(v)
         } else {
-            Err("JPEG Encoding Settings error: JPEG quality requires a number between 1 and 100 (inclusive).".to_string())
+            bail!("JPEG Encoding Settings error: JPEG quality requires a number between 1 and 100 (inclusive).")
         }
     }
 

--- a/src/app/license.rs
+++ b/src/app/license.rs
@@ -1,24 +1,26 @@
 use crate::app::config::SelectedLicenses;
+use anyhow::anyhow;
 use inflate::inflate_bytes;
 
 const LICENSE_SELF: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/LICENSE",));
 const LICENSE_DEPS: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/compressed_dep_licenses"));
 
 pub(crate) trait PrintTextFor {
-    fn print(&self) -> Result<(), String>;
+    fn print(&self) -> anyhow::Result<()>;
 }
 
 impl PrintTextFor for SelectedLicenses {
-    fn print(&self) -> Result<(), String> {
-        fn print_for_this_software() -> Result<(), String> {
+    fn print(&self) -> anyhow::Result<()> {
+        fn print_for_this_software() -> anyhow::Result<()> {
             println!("sic image tools license:\n\n{}\n\n", LICENSE_SELF);
 
             Ok(())
         }
 
-        fn print_for_dependencies() -> Result<(), String> {
-            let inflated = inflate_bytes(LICENSE_DEPS)?;
-            let text = std::str::from_utf8(&inflated).map_err(|err| err.to_string())?;
+        fn print_for_dependencies() -> anyhow::Result<()> {
+            let inflated = inflate_bytes(LICENSE_DEPS)
+                .map_err(|err| anyhow!("Unable to uncompress license text {}", err))?;
+            let text = std::str::from_utf8(&inflated).map_err(|err| anyhow!("{}", err))?;
 
             println!("{}", text);
 

--- a/src/app/operations.rs
+++ b/src/app/operations.rs
@@ -313,8 +313,7 @@ fn unify_arguments_of_operation(nodes: IndexedOps, size: usize) -> Result<Indexe
     Ok(vec)
 }
 
-const FAILED_UNIFICATION_MESSAGE: &str =
-    "Unification of multi valued argument(s) failed: \
+const FAILED_UNIFICATION_MESSAGE: &str = "Unification of multi valued argument(s) failed: \
      When using an image operation cli argument which requires n values, \
      all values should be provided at once. For example, `--crop` takes 4 values \
      so, n=4. Now, `--crop 0 0 1 1` would be valid, but `--crop 0 0 --crop 1 1` would not.";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,20 @@
+use anyhow::anyhow;
 use sic_lib::app::cli::build_app_config;
 use sic_lib::app::procedure::{run, run_display_licenses};
 
-fn main() -> Result<(), String> {
+fn main() -> anyhow::Result<()> {
     let app = sic_lib::app::cli::cli();
     let matches = app.get_matches();
 
     let license_display = matches.is_present("license") || matches.is_present("dep_licenses");
 
-    let configuration = build_app_config(&matches)?;
+    let configuration =
+        build_app_config(&matches).map_err(|_err| anyhow!("TODO . build app config"))?;
 
     if license_display {
         run_display_licenses(&configuration)
+            .map_err(|_err| anyhow!("TODO . run display licenses error"))
     } else {
-        run(&matches, &configuration)
+        run(&matches, &configuration).map_err(|_err| anyhow!("TODO . run error"))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-use anyhow::anyhow;
 use sic_lib::app::cli::build_app_config;
 use sic_lib::app::procedure::{run, run_display_licenses};
 
@@ -8,13 +7,11 @@ fn main() -> anyhow::Result<()> {
 
     let license_display = matches.is_present("license") || matches.is_present("dep_licenses");
 
-    let configuration =
-        build_app_config(&matches).map_err(|_err| anyhow!("TODO . build app config"))?;
+    let configuration = build_app_config(&matches)?;
 
     if license_display {
         run_display_licenses(&configuration)
-            .map_err(|_err| anyhow!("TODO . run display licenses error"))
     } else {
-        run(&matches, &configuration).map_err(|_err| anyhow!("TODO . run error"))
+        run(&matches, &configuration)
     }
 }

--- a/tests/cli_convert.rs
+++ b/tests/cli_convert.rs
@@ -67,7 +67,7 @@ fn convert_to_bmp_by_extension() {
 
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -86,7 +86,7 @@ fn convert_to_gif_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -105,7 +105,7 @@ fn convert_to_jpg_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -124,7 +124,7 @@ fn convert_to_jpeg_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -143,7 +143,7 @@ fn convert_to_png_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -162,7 +162,7 @@ fn convert_to_ico_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -181,7 +181,7 @@ fn convert_to_pbm_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -200,7 +200,7 @@ fn convert_to_pgm_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -219,7 +219,7 @@ fn convert_to_ppm_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -238,7 +238,7 @@ fn convert_to_pam_by_extension() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -274,7 +274,7 @@ fn convert_to_bmp_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -296,7 +296,7 @@ fn convert_to_gif_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -318,7 +318,7 @@ fn convert_to_ico_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -340,7 +340,7 @@ fn convert_to_jpg_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -362,7 +362,7 @@ fn convert_to_jpeg_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -384,7 +384,7 @@ fn convert_to_png_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -406,7 +406,7 @@ fn convert_to_pbm_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -428,7 +428,7 @@ fn convert_to_pgm_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -450,7 +450,7 @@ fn convert_to_ppm_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -472,7 +472,7 @@ fn convert_to_pam_by_ff() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
     assert!(is_image_format(
         path_buf_str(&our_output),
@@ -530,7 +530,7 @@ fn convert_pbm_ascii() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
 
     // read file contents
@@ -561,7 +561,7 @@ fn convert_pgm_ascii() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
 
     // read file contents
@@ -592,7 +592,7 @@ fn convert_ppm_ascii() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
 
     // read file contents
@@ -622,7 +622,7 @@ fn convert_pbm_not_ascii() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
 
     // read file contents
@@ -652,7 +652,7 @@ fn convert_pgm_not_ascii() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
 
     // read file contents
@@ -682,7 +682,7 @@ fn convert_ppm_not_ascii() {
     let matches = get_app().get_matches_from(args);
     let complete = run(&matches, &build_app_config(&matches).unwrap());
 
-    assert_eq!(Ok(()), complete);
+    assert_eq!((), complete.unwrap());
     assert!(our_output.exists());
 
     // read file contents
@@ -725,12 +725,11 @@ fn convert_jpeg_quality_different() {
     ];
 
     let matches1 = get_app().get_matches_from(args1);
-    let complete1 = run(&matches1, &build_app_config(&matches1).unwrap());
+    let complete1 = run(&matches1, &build_app_config(&matches1).unwrap()).unwrap();
 
     let matches2 = get_app().get_matches_from(args2);
-    let complete2 = run(&matches2, &build_app_config(&matches2).unwrap());
+    let complete2 = run(&matches2, &build_app_config(&matches2).unwrap()).unwrap();
 
-    assert_eq!((Ok(()), Ok(())), (complete1, complete2));
     assert!(out1.exists() && out2.exists());
 
     // read file contents

--- a/tests/cli_convert.rs
+++ b/tests/cli_convert.rs
@@ -725,10 +725,10 @@ fn convert_jpeg_quality_different() {
     ];
 
     let matches1 = get_app().get_matches_from(args1);
-    let complete1 = run(&matches1, &build_app_config(&matches1).unwrap()).unwrap();
+    run(&matches1, &build_app_config(&matches1).unwrap()).unwrap();
 
     let matches2 = get_app().get_matches_from(args2);
-    let complete2 = run(&matches2, &build_app_config(&matches2).unwrap()).unwrap();
+    run(&matches2, &build_app_config(&matches2).unwrap()).unwrap();
 
     assert!(out1.exists() && out2.exists());
 

--- a/tests/cli_image_operation_args.rs
+++ b/tests/cli_image_operation_args.rs
@@ -113,7 +113,7 @@ mod crop {
 
     #[test]
     fn crop_too_few() {
-        let mut process = command(DEFAULT_IN, "cio_crop7.png", "--crop 2 2 2");
+        let mut process = command(DEFAULT_IN, "cio_crop7.png", "--crop 0 0 2");
         let result = process.wait();
         assert!(result.is_ok());
 
@@ -122,7 +122,25 @@ mod crop {
 
     #[test]
     fn crop_too_many() {
-        let mut process = command(DEFAULT_IN, "cio_crop8.png", "--crop 2 2 2 2 2");
+        let mut process = command(DEFAULT_IN, "cio_crop8.png", "--crop 0 0 2 2 2");
+        let result = process.wait();
+        assert!(result.is_ok());
+
+        assert_not!(result.unwrap().success());
+    }
+
+    #[test]
+    fn crop_invalid_selection() {
+        let mut process = command(DEFAULT_IN, "cio_crop9.png", "--crop 1 1 1 1");
+        let result = process.wait();
+        assert!(result.is_ok());
+
+        assert_not!(result.unwrap().success());
+    }
+
+    #[test]
+    fn crop_out_of_bounds_selection() {
+        let mut process = command(DEFAULT_IN, "cio_crop9.png", "--crop 1 1 10 10");
         let result = process.wait();
         assert!(result.is_ok());
 


### PR DESCRIPTION
This PR replaces custom enum based errors, String errors (majority) and Box<dyn Error> based error handling.

The majority of the code based used to use string based
error handling. Strings are not great for error handling since they
prevent many diagnostic decorations.
If we were to use the std library error handling we would be implementing
std::error::Error and std::fmt::Display (and sometimes std::convert::From).
This can quickly become a verbose task, but it is also straightforward,
easy to maintain and works well for compatibility.

To reduce verbosity I've selected the thiserror crate which is compatible
with the std library method. This crate provides attribute macros which
help with implementing Display, Error and From amongst others.

The bin part of the project will use the anyhow crate by the same author.
Anyhow helps by providing additional contexts and is used
instead of Box<dyn Error>. 

More about error handling can be found here:
https://blog.burntsushi.net/rust-error-handling/

The article is a few years old, yet still relevant for error handling using
the std library.

issue: #12 