### PR TITLE
New argument parser specifically for cli image operations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           # pinned rust version :: ubuntu
           - build: pinned
             os: ubuntu-18.04
-            rust: 1.36.0
+            rust: 1.39.0
 
           # latest rust stable :: ubuntu
           - build: stable

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,11 +480,20 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "flate2 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "inflate 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sic_cli_operations 0.10.0-dev",
  "sic_core 0.10.0",
  "sic_image_engine 0.10.0",
  "sic_io 0.10.0",
  "sic_parser 0.10.0",
  "sic_testing 0.10.0",
+]
+
+[[package]]
+name = "sic_cli_operations"
+version = "0.10.0-dev"
+dependencies = [
+ "parameterized 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ categories = ["multimedia::images", "command-line-utilities"]
 
 [workspace]
 members = [
+  "components/sic_cli_operations",
   "components/sic_core",
   "components/sic_image_engine",
   "components/sic_io",
@@ -25,6 +26,7 @@ members = [
 ]
 
 [dependencies]
+sic_cli_operations = { path = "components/sic_cli_operations" }
 sic_core = { path = "components/sic_core", version = "0.10" }
 sic_image_engine = { path = "components/sic_image_engine", version = "0.10" }
 sic_io  = { path = "components/sic_io", version = "0.10" }

--- a/components/sic_cli_operations/Cargo.toml
+++ b/components/sic_cli_operations/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "sic_cli_operations"
+version = "0.10.0-dev"
+authors = ["Martijn Gribnau <garm@ilumeo.com>"]
+description = "Component of the sic cli: parses image operation cli arguments."
+edition = "2018"
+license-file = "../../LICENSE"
+repository = "https://github.com/foresterre/sic"
+
+[dependencies]
+thiserror = "1.0.14"
+
+[dev-dependencies]
+parameterized = "0.1.1"

--- a/components/sic_cli_operations/src/errors.rs
+++ b/components/sic_cli_operations/src/errors.rs
@@ -1,0 +1,28 @@
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+pub enum SicArgError {
+    #[error("A long argument name (--name) should consist of at least two characters")]
+    LongArgTokenLength,
+
+    #[error("A long argument name (--name) should consist of alphanumeric characters, or valid character followed by single dash followed by a valid character")]
+    LongArgAcceptedCharacters,
+
+    #[error("The name of a long argument (--name) can't start with a dash or end in a dash")]
+    LongArgFirstAndLastCharNotDashes,
+
+    #[error("The name of a long argument (--name) can't consist of consecutive dashes")]
+    LongArgNoConsecutiveDashes,
+
+    #[error("Insufficient argument length: a short argument should consist of a single character")]
+    ShortArgTokenLength,
+
+    #[error("A short argument should consist of an alphabetic character")]
+    ShortArgAcceptedCharacter,
+
+    #[error("Unable to tokenize input")]
+    TokenizeError,
+
+    #[error("Token '{0}' was not recognized as a valid token")]
+    UnrecognizedToken(String),
+}

--- a/components/sic_cli_operations/src/lib.rs
+++ b/components/sic_cli_operations/src/lib.rs
@@ -1,0 +1,289 @@
+//! sic_cli_operations is a lexer and parser for cli arguments, specifically those related to image operations.
+//! This parser will complement Clap which is used for ordinary cli arguments.
+//! Specifically, it should only parse (image) operations and skip non image operations.
+//!
+//! Supported:
+//! - long args
+//! - short args
+//!
+//! Unsupported:
+//! - positional arguments
+//! - Invoked program, so the first raw cli argument should be removed from the iterator.
+//! - Flag repetitions (e.g. -vvv instead of -v -v -v)
+//! - Values given to long args and short args which start with `--` or `-`.
+
+#![deny(
+    future_incompatible,
+    missing_copy_implementations,
+    missing_debug_implementations,
+    nonstandard_style,
+    trivial_casts,
+    trivial_numeric_casts,
+    unused
+)]
+
+// Example of input given by args():
+//
+// If we run sic with `sic --run-external "oxipng -i 3 {input} --some-flag"`, std::env::args() gives us the
+// following elements (nth element > arg):
+// 0 > sic
+// 1 > --run-external
+// 2 > oxipng -i 3 {input} --some-flag
+
+#[cfg(test)]
+#[macro_use]
+extern crate parameterized;
+
+use crate::errors::SicArgError;
+use crate::validation::long_arg::{
+    LongArgAcceptedCharsValidator, LongArgFirstAndLastCharNotDashesValidator,
+    LongArgLengthValidator, LongArgNoConsecutiveDashesValidator,
+};
+use crate::validation::short_arg::{ShortArgAcceptedCharValidator, ShortArgLengthValidator};
+use crate::validation::{validate_argument_name, Validate};
+
+pub mod errors;
+pub(crate) mod validation;
+
+#[derive(Debug)]
+pub struct Tokenizer<'a> {
+    /// White space separated elements
+    chunks: &'a [&'a str],
+
+    /// The current chunk
+    pos: usize,
+}
+
+impl<'a> Tokenizer<'a> {
+    pub fn new(cli_args: &'a [&'a str]) -> Self {
+        Self {
+            chunks: cli_args,
+            pos: 0,
+        }
+    }
+
+    pub fn tokens(&mut self) -> Result<Vec<Token<'a>>, errors::SicArgError> {
+        self.collect::<Result<Vec<_>, errors::SicArgError>>()
+    }
+
+    fn consume_token(&mut self) -> Result<Token<'a>, errors::SicArgError> {
+        if let Some(w) = self.chunks.get(self.pos) {
+            let token_result = match w {
+                w if w.starts_with("--") => {
+                    let name = &w[2..];
+
+                    let v0: &dyn Validate = &LongArgLengthValidator(name);
+                    let v1: &dyn Validate = &LongArgAcceptedCharsValidator(name);
+                    let v2: &dyn Validate = &LongArgNoConsecutiveDashesValidator(name);
+                    let v3: &dyn Validate = &LongArgFirstAndLastCharNotDashesValidator(name);
+                    validate_argument_name(&[v0, v1, v2, v3])?;
+
+                    Ok(Token {
+                        typ: TokenType::LongArg,
+                        slice: name,
+                    })
+                }
+                w if w.starts_with('-') => {
+                    let name = &w[1..];
+
+                    let v0: &dyn Validate = &ShortArgLengthValidator(name);
+                    let v1: &dyn Validate = &ShortArgAcceptedCharValidator(name);
+                    validate_argument_name(&[v0, v1])?;
+
+                    Ok(Token {
+                        typ: TokenType::ShortArg,
+                        slice: name,
+                    })
+                }
+                w if w.chars().all(|c| !c.is_ascii_control()) => Ok(Token {
+                    typ: TokenType::ArgValue,
+                    slice: w,
+                }),
+                err => Err(SicArgError::UnrecognizedToken((*err).to_string())),
+            };
+
+            self.pos += 1;
+
+            token_result
+        } else {
+            Err(SicArgError::TokenizeError)
+        }
+    }
+}
+
+impl<'a> Iterator for Tokenizer<'a> {
+    type Item = Result<Token<'a>, errors::SicArgError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos < self.chunks.len() {
+            Some(self.consume_token())
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Token<'a> {
+    typ: TokenType,
+    slice: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TokenType {
+    /// Argument starting with `--`, e.g. `--example`.
+    LongArg,
+
+    /// Argument starting with `-`, e.g. `-a`.
+    ShortArg,
+
+    /// "" or '' delimited string, or a single word
+    ArgValue,
+}
+
+#[cfg(test)]
+mod tokenizer_tests {
+    use crate::{Token, TokenType, Tokenizer};
+
+    mod pm {
+        use super::*;
+
+        parameterized::ide!();
+
+        #[parameterized(
+            input = {
+                "-o",
+                "--out",
+                "v",
+                "x y",
+                "x, y"
+            },
+            expected = {
+                Token {
+                    typ: TokenType::ShortArg,
+                    slice: "o"
+                },
+                Token {
+                    typ: TokenType::LongArg,
+                    slice: "out"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "v"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "x y"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "x, y"
+                },
+            }
+        )]
+        fn tokens(input: &str, expected: Token) {
+            let args = &[input];
+            let mut tokenizer = Tokenizer::new(args);
+            assert_eq!(tokenizer.tokens().unwrap(), vec![expected]);
+        }
+    }
+
+    #[test]
+    fn token_types() {
+        let mut tokenizer = Tokenizer::new(&[
+            "-o", "a", "--two", "b", "--three", "--four", "val x", "--five", "val y",
+        ]);
+        let tokens = tokenizer.tokens();
+
+        assert_eq!(
+            tokens.unwrap(),
+            vec![
+                Token {
+                    typ: TokenType::ShortArg,
+                    slice: "o"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "a"
+                },
+                Token {
+                    typ: TokenType::LongArg,
+                    slice: "two"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "b"
+                },
+                Token {
+                    typ: TokenType::LongArg,
+                    slice: "three"
+                },
+                Token {
+                    typ: TokenType::LongArg,
+                    slice: "four"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "val x"
+                },
+                Token {
+                    typ: TokenType::LongArg,
+                    slice: "five"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "val y"
+                }
+            ]
+        )
+    }
+
+    #[test]
+    fn token_types_with_long_arg_as_arg_value() {
+        let mut tokenizer = Tokenizer::new(&[
+            "-i",
+            "input.png",
+            "--output",
+            "out.png",
+            "--run-external",
+            "oxipng -i 3 {input} --some-flag",
+        ]);
+        let tokens = tokenizer.tokens();
+
+        assert_eq!(
+            tokens.unwrap(),
+            vec![
+                Token {
+                    typ: TokenType::ShortArg,
+                    slice: "i"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "input.png"
+                },
+                Token {
+                    typ: TokenType::LongArg,
+                    slice: "output"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "out.png"
+                },
+                Token {
+                    typ: TokenType::LongArg,
+                    slice: "run-external"
+                },
+                Token {
+                    typ: TokenType::ArgValue,
+                    slice: "oxipng -i 3 {input} --some-flag"
+                },
+            ]
+        )
+    }
+}
+
+/// Known list of operations to parse
+#[derive(Copy, Clone, Debug)]
+pub enum _OpC {
+    Blur,
+}

--- a/components/sic_cli_operations/src/validation/long_arg.rs
+++ b/components/sic_cli_operations/src/validation/long_arg.rs
@@ -1,0 +1,201 @@
+//! Validators which check whether the given characters make the argument a valid long argument token.
+//! A long argument has the following shape: `--name`, where `name` satisfies the following properties:
+//! * |name| >= 2
+//! * name is alphanumeric or a dash
+//! * name doesn't contain a consecutive dash
+//! * name's first and last characters aren't dashes
+
+use crate::errors::SicArgError;
+use crate::validation::Validate;
+
+pub(crate) const DASH: char = '-';
+
+pub struct LongArgLengthValidator<'a>(pub(crate) &'a str);
+
+impl Validate for LongArgLengthValidator<'_> {
+    fn validate(&self) -> Result<(), SicArgError> {
+        if self.0.len() >= 2 {
+            Ok(())
+        } else {
+            Err(SicArgError::LongArgTokenLength)
+        }
+    }
+}
+
+#[cfg(test)]
+mod length_validator {
+    use super::*;
+
+    #[test]
+    fn happy() {
+        let validator = LongArgLengthValidator("aa");
+        assert!(validator.validate().is_ok())
+    }
+
+    #[parameterized(
+        input = {
+            "a",
+            ""
+        }
+    )]
+    fn sad(input: &str) {
+        let validator = LongArgLengthValidator(input);
+        assert_eq!(
+            validator.validate().unwrap_err(),
+            SicArgError::LongArgTokenLength
+        )
+    }
+}
+
+pub struct LongArgAcceptedCharsValidator<'a>(pub(crate) &'a str);
+
+impl Validate for LongArgAcceptedCharsValidator<'_> {
+    fn validate(&self) -> Result<(), SicArgError> {
+        if self.0.chars().all(|c| c.is_alphanumeric() || c == DASH) {
+            Ok(())
+        } else {
+            Err(SicArgError::LongArgAcceptedCharacters)
+        }
+    }
+}
+
+#[cfg(test)]
+mod accepted_chars_validator {
+    use super::*;
+
+    parameterized::ide!();
+
+    #[parameterized(
+        input = {
+            "a",
+            "1",
+            "-",
+            "a-1z",
+            "ß"
+        }
+    )]
+    fn happy(input: &str) {
+        let validator = LongArgAcceptedCharsValidator(input);
+        assert!(validator.validate().is_ok())
+    }
+
+    #[parameterized(
+        input = {
+            ",",
+            ".",
+            "!",
+            "~",
+            "—", // em dash
+            "―", // horizontal bar
+            "‒", // figure dash
+            "​", // zero width space
+        }
+    )]
+    fn sad(input: &str) {
+        let validator = LongArgAcceptedCharsValidator(input);
+        assert_eq!(
+            validator.validate().unwrap_err(),
+            SicArgError::LongArgAcceptedCharacters
+        )
+    }
+}
+
+pub struct LongArgNoConsecutiveDashesValidator<'a>(pub(crate) &'a str);
+
+impl Validate for LongArgNoConsecutiveDashesValidator<'_> {
+    fn validate(&self) -> Result<(), SicArgError> {
+        let windows: Vec<char> = self.0.chars().collect();
+        let windows = windows.windows(2);
+
+        for window in windows {
+            let lhs = window.get(0);
+            let rhs = window.get(1);
+
+            if let Some(l) = lhs {
+                if let Some(r) = rhs {
+                    if *l == DASH && *r == DASH {
+                        return Err(SicArgError::LongArgNoConsecutiveDashes);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod no_consecutive_dashes_validator {
+    use super::*;
+
+    parameterized::ide!();
+
+    #[parameterized(
+        input = {
+            "a-a",
+            "-a-",
+            "a-a-",
+            "-a-a",
+        }
+    )]
+    fn happy(input: &str) {
+        let validator = LongArgNoConsecutiveDashesValidator(input);
+        assert!(validator.validate().is_ok());
+    }
+
+    #[parameterized(
+        input = {
+            "a--a",
+            "a--",
+            "--a",
+        }
+    )]
+    fn sad(input: &str) {
+        let validator = LongArgNoConsecutiveDashesValidator(input);
+        assert_eq!(
+            validator.validate().unwrap_err(),
+            SicArgError::LongArgNoConsecutiveDashes
+        );
+    }
+}
+
+pub struct LongArgFirstAndLastCharNotDashesValidator<'a>(pub(crate) &'a str);
+
+impl Validate for LongArgFirstAndLastCharNotDashesValidator<'_> {
+    fn validate(&self) -> Result<(), SicArgError> {
+        let first = self.0.chars().next();
+        let last = self.0.chars().next_back();
+
+        match (first, last) {
+            (Some(first), Some(last)) if first != DASH && last != DASH => Ok(()),
+            _ => Err(SicArgError::LongArgFirstAndLastCharNotDashes),
+        }
+    }
+}
+
+#[cfg(test)]
+mod first_and_last_char_not_dashes_validator {
+    use super::*;
+
+    #[test]
+    fn happy() {
+        let validator = LongArgFirstAndLastCharNotDashesValidator("a-----a");
+        assert!(validator.validate().is_ok());
+    }
+
+    #[parameterized(
+        input = {
+            "-",
+            "-a",
+            "a-",
+            "-a-"
+        }
+    )]
+    fn sad(input: &str) {
+        let validator = LongArgFirstAndLastCharNotDashesValidator(input);
+        assert_eq!(
+            validator.validate().unwrap_err(),
+            SicArgError::LongArgFirstAndLastCharNotDashes
+        );
+    }
+}

--- a/components/sic_cli_operations/src/validation/mod.rs
+++ b/components/sic_cli_operations/src/validation/mod.rs
@@ -1,0 +1,47 @@
+use crate::errors;
+use crate::errors::SicArgError;
+
+pub mod long_arg;
+pub mod short_arg;
+
+pub trait Validate {
+    fn validate(&self) -> Result<(), errors::SicArgError>;
+}
+
+pub fn validate_argument_name<'a>(validators: &'a [&'a dyn Validate]) -> Result<(), SicArgError> {
+    for validator in validators {
+        if let e @ Err(_) = validator.validate() {
+            return e;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validation::short_arg::{ShortArgAcceptedCharValidator, ShortArgLengthValidator};
+
+    #[test]
+    fn check_with_ok() {
+        let key = "a";
+        let v1: &dyn Validate = &ShortArgLengthValidator(key);
+        let v2: &dyn Validate = &ShortArgAcceptedCharValidator(key);
+
+        let validation = validate_argument_name(&[v1, v2]);
+
+        assert!(validation.is_ok())
+    }
+
+    #[test]
+    fn check_with_err() {
+        let key = "!";
+        let v1: &dyn Validate = &ShortArgLengthValidator(key);
+        let v2: &dyn Validate = &ShortArgAcceptedCharValidator(key);
+
+        let validation = validate_argument_name(&[v1, v2]);
+
+        assert!(validation.is_err())
+    }
+}

--- a/components/sic_cli_operations/src/validation/short_arg.rs
+++ b/components/sic_cli_operations/src/validation/short_arg.rs
@@ -1,0 +1,88 @@
+//! Validators which check whether the given characters make the argument a valid short argument token.
+//! A short argument has the following shape: `-x`, where `x` satisfies the following properties:
+//! * |x| = 1
+//! * x is alphabetic
+
+use crate::errors::SicArgError;
+use crate::validation::Validate;
+
+pub struct ShortArgLengthValidator<'a>(pub(crate) &'a str);
+
+impl Validate for ShortArgLengthValidator<'_> {
+    fn validate(&self) -> Result<(), SicArgError> {
+        if self.0.len() == 1 {
+            Ok(())
+        } else {
+            Err(SicArgError::ShortArgTokenLength)
+        }
+    }
+}
+
+#[cfg(test)]
+mod length_validator {
+    use super::*;
+
+    #[test]
+    fn happy() {
+        let v = ShortArgLengthValidator("a");
+        let validation = v.validate();
+        assert!(validation.is_ok())
+    }
+
+    #[test]
+    fn sad() {
+        let v = ShortArgLengthValidator("aa");
+        let validation = v.validate();
+        assert_eq!(validation.unwrap_err(), SicArgError::ShortArgTokenLength)
+    }
+}
+
+pub struct ShortArgAcceptedCharValidator<'a>(pub(crate) &'a str);
+
+impl Validate for ShortArgAcceptedCharValidator<'_> {
+    fn validate(&self) -> Result<(), SicArgError> {
+        if let Some(c) = self.0.chars().next() {
+            if c.is_alphabetic() {
+                return Ok(());
+            }
+        }
+
+        Err(SicArgError::ShortArgAcceptedCharacter)
+    }
+}
+
+#[cfg(test)]
+mod accepted_char {
+    use super::*;
+
+    parameterized::ide!();
+
+    #[parameterized(
+        input = {
+            "a",
+            "z",
+            "ß",
+        }
+    )]
+    fn happy(input: &str) {
+        let v = ShortArgAcceptedCharValidator(input);
+        let validation = v.validate();
+        assert!(validation.is_ok())
+    }
+
+    #[parameterized(
+        input = {
+            "!",
+            "1",
+            "",
+        }
+    )]
+    fn sad(input: &str) {
+        let v = ShortArgAcceptedCharValidator(input);
+        let validation = v.validate();
+        assert_eq!(
+            validation.unwrap_err(),
+            SicArgError::ShortArgAcceptedCharacter
+        )
+    }
+}


### PR DESCRIPTION
for cli image operations such as `--resize` and `--blur` in  `sic -i in.png -o out.png --resize 100 100 --blur 0.5` but not `--apply-operations "resize 100 100; blur 0.5", which uses sic_parser.
