### PR TITLE
Set the default sampling filter for resize to Lanczos3.

### DIFF
--- a/components/sic_image_engine/src/engine.rs
+++ b/components/sic_image_engine/src/engine.rs
@@ -314,13 +314,11 @@ impl CropSelection {
     }
 }
 
-const DEFAULT_RESIZE_FILTER: FilterType = FilterType::Gaussian;
-
 fn resize_filter_or_default(env: &mut Env) -> FilterType {
     env.get(ItemName::CustomSamplingFilter)
         .and_then(|item| item.resize_sampling_filter())
         .map(FilterType::from)
-        .unwrap_or(DEFAULT_RESIZE_FILTER)
+        .unwrap_or_else(|| FilterTypeWrap::default().into())
 }
 
 #[cfg(test)]

--- a/components/sic_image_engine/src/wrapper/filter_type.rs
+++ b/components/sic_image_engine/src/wrapper/filter_type.rs
@@ -14,6 +14,14 @@ impl FilterTypeWrap {
     }
 }
 
+impl Default for FilterTypeWrap {
+    fn default() -> Self {
+        Self {
+            inner: FilterType::Lanczos3,
+        }
+    }
+}
+
 impl PartialEq<FilterTypeWrap> for FilterTypeWrap {
     fn eq(&self, other: &FilterTypeWrap) -> bool {
         std::mem::discriminant(&self.inner) == std::mem::discriminant(&other.inner)


### PR DESCRIPTION
Lanczos3 produces subjectively an improved image quality (mostly sharper) compared to the current default, which uses a Gaussian filter.
According to a single test case located in the image docs [1], Lanczos3 would have a similar computing cost compared a Gaussian filter. This cost is relatively higher than nearest neighbor, triangle or a Catmull-Rom filter, but produces subjectively the best quality images. For now we will opt to use the "highest available quality" and we can use the resize_sampling_filter option to use another filter if so desired (for example if the computing cost would be too high).
Admittedly, this switch is based on some subjectivity and assumptions. We should aim to test, benchmark and properly study these sampling filters in the future.

[1] https://docs.rs/image/0.23.4/image/imageops/enum.FilterType.html

related #338
closes #339