### PR TITLE
Port error handling of sic_cli_ops to thiserror.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,7 +503,6 @@ dependencies = [
 name = "sic_cli_ops"
 version = "0.10.0"
 dependencies = [
- "anyhow 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sic_cli 0.10.0",
  "sic_image_engine 0.10.0",
@@ -511,6 +510,7 @@ dependencies = [
  "sic_testing 0.10.0",
  "strum 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "strum_macros 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/components/sic_cli_ops/Cargo.toml
+++ b/components/sic_cli_ops/Cargo.toml
@@ -11,10 +11,10 @@ repository = "https://github.com/foresterre/sic"
 sic_image_engine = { path = "../../components/sic_image_engine", version = "0.10" }
 sic_parser = { path = "../../components/sic_parser", version = "0.10" }
 
-anyhow = "1.0.28"
 clap = "2.33.0"
 strum = "0.18.0"
 strum_macros = "0.18.0"
+thiserror = "1.0.15"
 
 [dev-dependencies]
 sic_cli = { path = "../../components/sic_cli" } # careful! potential circular dependency!

--- a/components/sic_cli_ops/src/errors.rs
+++ b/components/sic_cli_ops/src/errors.rs
@@ -1,0 +1,28 @@
+use sic_parser::errors::SicParserError;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum SicCliOpsError {
+    #[error("Unable to parse: {0}")]
+    ParserError(#[from] SicParserError),
+
+    #[error("Failed to parse value of type {typ} ({err})")]
+    UnableToParseValueOfType { err: SicParserError, typ: String },
+
+    #[error(
+        "Unification of multi valued argument(s) failed: arguments couldn't be \
+         partitioned in correct chunk sizes. Length of chunk: {0}"
+    )]
+    UnableToCorrectlyPartitionMultiParamArguments(usize),
+
+    #[error(
+        "Unification of multi valued argument(s) failed: \
+        When using an image operation cli argument which requires n values, \
+        all values should be provided at once. For example, `--crop` takes 4 values \
+        so, n=4. Now, `--crop 0 0 1 1` would be valid, but `--crop 0 0 --crop 1 1` would not."
+    )]
+    UnableToUnifyMultiValuedArguments,
+
+    #[error("Values which take no arguments can't be unified")]
+    UnableToUnifyBareValues,
+}

--- a/components/sic_cli_ops/src/lib.rs
+++ b/components/sic_cli_ops/src/lib.rs
@@ -5,16 +5,18 @@ use clap::ArgMatches;
 
 use sic_image_engine::engine::Instr;
 
+use crate::errors::SicCliOpsError;
 use crate::operations::{
     extend_index_tree_with_unification, IndexTree, IndexedOps, Op, OperationId,
 };
 
+pub mod errors;
 pub mod operations;
 
 pub fn build_ast_from_matches(
     matches: &ArgMatches,
     tree: &mut IndexTree,
-) -> anyhow::Result<Vec<Instr>> {
+) -> Result<Vec<Instr>, SicCliOpsError> {
     use strum::IntoEnumIterator;
 
     let operations = OperationId::iter();
@@ -28,7 +30,7 @@ fn ast_extend_with_operation<T: IntoIterator<Item = OperationId>>(
     tree: &mut IndexTree,
     matches: &ArgMatches,
     operations: T,
-) -> anyhow::Result<()> {
+) -> Result<(), SicCliOpsError> {
     for operation in operations {
         let argc = operation.takes_number_of_arguments();
         let ops = mk_ops(operation, matches);
@@ -46,7 +48,7 @@ fn mk_ops(op: OperationId, matches: &ArgMatches) -> Option<IndexedOps> {
     }
 }
 
-fn ast_from_index_tree(tree: &mut IndexTree) -> anyhow::Result<Vec<Instr>> {
+fn ast_from_index_tree(tree: &mut IndexTree) -> Result<Vec<Instr>, SicCliOpsError> {
     tree.iter()
         .map(|(_index, op)| match op {
             Op::Bare(id) => {
@@ -55,7 +57,7 @@ fn ast_from_index_tree(tree: &mut IndexTree) -> anyhow::Result<Vec<Instr>> {
             }
             Op::WithValues(id, values) => id.mk_statement(values),
         })
-        .collect::<anyhow::Result<Vec<Instr>>>()
+        .collect::<Result<Vec<Instr>, SicCliOpsError>>()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Previously we used anyhow, because this module was split (to its own library) from the binary crate.

closes #364