### PR TITLE
pipeline::run depended on both argmatches and config while it should only use locally known data

### DIFF
--- a/components/sic_cli/src/cli.rs
+++ b/components/sic_cli/src/cli.rs
@@ -300,6 +300,10 @@ pub fn build_app_config<'a>(matches: &'a ArgMatches) -> anyhow::Result<Config<'a
         (false, false) => (),
     };
 
+    if let Some(path) = matches.value_of(ARG_INPUT) {
+        builder = builder.input_path(path);
+    }
+
     // io(output):
     if let Some(path) = matches.value_of(ARG_OUTPUT) {
         builder = builder.output_path(path);

--- a/components/sic_cli/src/config.rs
+++ b/components/sic_cli/src/config.rs
@@ -11,26 +11,23 @@ pub struct Config<'a> {
     /// Display license of this software or its dependencies.
     pub show_license_text_of: Option<SelectedLicenses>,
 
-    // io(output)
+    ///
+    pub input: Option<&'a str>,
+
     /// The image output path.
     pub output: Option<&'a str>,
 
-    // config(in)
     pub selected_frame: FrameIndex,
 
-    // config(out)
     /// Disable color type adjustments on save.
     pub disable_automatic_color_type_adjustment: bool,
 
-    // config(out)
     /// Format to which an image will be converted (enforced).
     pub forced_output_format: Option<&'a str>,
 
-    // config(out)
     /// Encoding settings for specific output formats.
     pub encoding_settings: FormatEncodingSettings,
 
-    // image-operations
     /// If a user wants to perform image operations on input image, they will need to provide
     /// the image operation commands.
     /// THe value set here should be presented as a [sic_image_engine::engine::Program].
@@ -46,6 +43,10 @@ impl Default for Config<'_> {
 
             /// Defaults to no displayed license text.
             show_license_text_of: None,
+
+            /// Default input path is None. The program may require an input to be set
+            /// for most of its program behaviour.
+            input: None,
 
             /// Default output path is None. The program may require an output to be set
             /// for most of its program behaviour.
@@ -124,6 +125,11 @@ impl<'a> ConfigBuilder<'a> {
     // config(out)
     pub fn pnm_format_type(mut self, use_ascii: bool) -> ConfigBuilder<'a> {
         self.settings.encoding_settings.pnm_use_ascii_format = use_ascii;
+        self
+    }
+
+    pub fn input_path(mut self, path: &'a str) -> ConfigBuilder<'a> {
+        self.settings.input = Some(path);
         self
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,6 @@ fn main() -> anyhow::Result<()> {
             &LicenseTexts::new(LICENSE_SELF, LICENSE_DEPS),
         )
     } else {
-        run(&matches, &configuration)
+        run(&configuration)
     }
 }

--- a/tests/cli_convert.rs
+++ b/tests/cli_convert.rs
@@ -101,7 +101,7 @@ mod convert_to_x {
         ];
         let matches = get_app().get_matches_from(args);
 
-        let complete = run(&matches, &build_app_config(&matches).unwrap());
+        let complete = run(&build_app_config(&matches).unwrap());
 
         complete.unwrap();
         assert!(output_path.exists());
@@ -160,7 +160,7 @@ mod convert_to_x_by_ff {
 
         let args = args(which, &input_path, &output_path);
         let matches = get_app().get_matches_from(args);
-        let complete = run(&matches, &build_app_config(&matches).unwrap());
+        let complete = run(&build_app_config(&matches).unwrap());
 
         complete.unwrap();
         assert!(output_path.exists());
@@ -226,7 +226,7 @@ mod pnm_ascii_and_binary {
         args.push(path_buf_str(&output_path));
 
         let matches = get_app().get_matches_from(args);
-        let complete = run(&matches, &build_app_config(&matches).unwrap());
+        let complete = run(&build_app_config(&matches).unwrap());
 
         complete.unwrap();
         assert!(output_path.exists());
@@ -297,10 +297,10 @@ fn convert_jpeg_quality_different() {
     ];
 
     let matches1 = get_app().get_matches_from(args1);
-    run(&matches1, &build_app_config(&matches1).unwrap()).unwrap();
+    run(&build_app_config(&matches1).unwrap()).unwrap();
 
     let matches2 = get_app().get_matches_from(args2);
-    run(&matches2, &build_app_config(&matches2).unwrap()).unwrap();
+    run(&build_app_config(&matches2).unwrap()).unwrap();
 
     assert!(out1.exists() && out2.exists());
 


### PR DESCRIPTION

This commit removes ArgMatches as an argument of pipeline::run. The aim is that it will enable us in the future
to run the pipeline in parallel with different inputs/outputs (which now becomes possible by setting the config
in- and output to different values, e.g. by allowing the input and output cli arguments to take multiple values).

This is an intermediate step, so we don't need to refactor and optimize the whole pipeline just yet.