### PR TITLE
Add an (direct) image crate output format decider fallback option

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -42,6 +42,7 @@ define_arg_consts!(arg_names, {
     ARG_FORCED_OUTPUT_FORMAT,
     ARG_JPEG_ENCODING_QUALITY,
     ARG_PNM_ENCODING_ASCII,
+    ARG_IMAGE_CRATE_FALLBACK,
 
     // provide image operations using image script
     ARG_APPLY_OPERATIONS,
@@ -147,6 +148,11 @@ pub fn create_app(
         .arg(Arg::with_name(ARG_PNM_ENCODING_ASCII)
             .long("pnm-encoding-ascii")
             .help("Use ascii based encoding when using a PNM image output format (pbm, pgm or ppm). Doesn't apply to 'pam' (PNM Arbitrary Map)."))
+
+        .arg(Arg::with_name(ARG_IMAGE_CRATE_FALLBACK)
+            .long("enable-output-format-decider-fallback")
+            .help("[experimental] When this flag is set, sic will attempt to fallback to an alternative output format decider (image crate version), \
+            *if* sic's own decider can't find a suitable format. Setting this flag may introduce unwanted behaviour; use with caution."))
 
         // image-operations(script):
         .arg(Arg::with_name(ARG_APPLY_OPERATIONS)
@@ -384,6 +390,10 @@ pub fn build_app_config<'a>(matches: &'a ArgMatches) -> anyhow::Result<Config<'a
     if matches.is_present(ARG_PNM_ENCODING_ASCII) {
         builder = builder.pnm_format_type(true);
     }
+
+    // config(out)/ARG_IMAGE_CRATE_FALLBACK:
+    builder =
+        builder.image_output_format_decider_fallback(matches.is_present(ARG_IMAGE_CRATE_FALLBACK));
 
     // image-operations:
     //

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -208,6 +208,14 @@ impl<'a> ConfigBuilder<'a> {
         self
     }
 
+    pub fn image_output_format_decider_fallback(
+        mut self,
+        enable_fallback: bool,
+    ) -> ConfigBuilder<'a> {
+        self.settings.encoding_settings.image_output_format_fallback = enable_fallback;
+        self
+    }
+
     // image-operations
     pub fn image_operations_program(mut self, program: Vec<Instr>) -> ConfigBuilder<'a> {
         self.settings.image_operations_program = program;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -140,6 +140,9 @@ impl Default for Config<'_> {
 
                 /// Default encoding type of PNM files (excluding PAM) is set to binary.
                 pnm_use_ascii_format: false,
+
+                /// Do not fallback to image crate output recognition by default
+                image_output_format_fallback: false,
             },
 
             /// Defaults to no provided image operations script.
@@ -228,6 +231,9 @@ pub enum SelectedLicenses {
 pub struct FormatEncodingSettings {
     pub jpeg_quality: u8,
     pub pnm_use_ascii_format: bool,
+
+    // Whether to fallback on the image crate to determine the output format if sic doesn't support it yet
+    pub image_output_format_fallback: bool,
 }
 
 /// Strictly speaking not necessary here since the responsible owners will validate the quality as well.

--- a/src/cli/pipeline/fallback.rs
+++ b/src/cli/pipeline/fallback.rs
@@ -1,0 +1,81 @@
+use std::path::Path;
+
+use sic_core::image::error::{ImageFormatHint, UnsupportedError};
+use sic_core::image::{ImageError, ImageFormat, ImageOutputFormat};
+use sic_io::errors::SicIoError;
+
+pub(crate) fn guess_output_by_identifier(id: &str) -> Result<ImageOutputFormat, SicIoError> {
+    // HACK: image crate doesn't use identifiers, so we'll use an extension as identifier
+    guess_output_by_path(Path::new(&format!("0.{}", id)))
+}
+
+pub(crate) fn guess_output_by_path<P: AsRef<Path>>(
+    path: P,
+) -> Result<ImageOutputFormat, SicIoError> {
+    ImageFormat::from_path(path)
+        .and_then(into_image_output_format)
+        .map_err(SicIoError::ImageError)
+}
+
+fn into_image_output_format(format: ImageFormat) -> Result<ImageOutputFormat, ImageError> {
+    let out = Into::<ImageOutputFormat>::into(format);
+
+    // Assuming we'll never hit the __NonExhaustive marker workaround by the image crate
+    match out {
+        ImageOutputFormat::Unsupported(name) => Err(ImageError::Unsupported(
+            UnsupportedError::from(ImageFormatHint::Name(name)),
+        )),
+        f => Ok(f),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    ide!();
+
+    #[parameterized(input = {
+        "jpg",
+        "jpeg",
+        "png",
+        "gif",
+        "bmp",
+        "ico",
+    }, expected = {
+        ImageOutputFormat::Jpeg(75),
+        ImageOutputFormat::Jpeg(75),
+        ImageOutputFormat::Png,
+        ImageOutputFormat::Gif,
+        ImageOutputFormat::Bmp,
+        ImageOutputFormat::Ico,
+    })]
+    fn formats_by_image_crate_ok(input: &str, expected: ImageOutputFormat) {
+        let by_id = guess_output_by_identifier(input).unwrap();
+        let by_path = guess_output_by_path(format!("my_file_name.{}", input)).unwrap();
+
+        assert_eq!(by_id, by_path);
+        assert_eq!(by_id, expected);
+    }
+    #[parameterized(input = {
+        "dds",
+        "hdr",
+        "docx",
+        "",
+        "😀",
+    })]
+    fn formats_by_image_crate_err(input: &str) {
+        let by_id = guess_output_by_identifier(input);
+        let by_path = guess_output_by_path(format!("my_file_name.{}", input));
+
+        assert!(by_id.is_err());
+        assert!(by_path.is_err());
+    }
+
+    #[test]
+    fn format_by_image_crate_err_no_ext() {
+        let by_path = guess_output_by_path("my_file_name");
+
+        assert!(by_path.is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,5 @@
+#[cfg(test)]
+#[macro_use]
+extern crate parameterized;
+
 pub mod cli;

--- a/tests/cli_output_format_decider_fallback.rs
+++ b/tests/cli_output_format_decider_fallback.rs
@@ -1,0 +1,22 @@
+#[macro_use]
+pub mod common;
+
+use crate::common::*;
+
+#[test]
+fn enable_output_decider_fallback_enabled() {
+    let mut process = command(
+        DEFAULT_IN,
+        "decider_fallback.ff",
+        "--enable-output-format-decider-fallback",
+    );
+    let result = process.wait();
+    assert!(result.unwrap().success());
+}
+
+#[test]
+fn enable_output_decider_fallback_not_enabled() {
+    let mut process = command(DEFAULT_IN, "decider_fallback.ff", "");
+    let result = process.wait();
+    assert_not!(result.unwrap().success());
+}


### PR DESCRIPTION
The `image` crate has a convenient built in way to determine the format which could be used for an output path called `ImageFormat::from_path`. It determines based on an extension, what format an image should be. `sic` has (for various reasons) its own, but similar,  built in way to handle the above problem. The disadvantage of using our own version is that for each added output format (by the same `image` crate 😄), we need to add an option to our image format decider to support the new format. In addition, we do currently not always support the same extensions/identifiers (e.g. farbfeld is supported by `sic` using the extension `farbfeld`, while the `image` crate also allows for `ff`).  This PR allows to fallback to the output format decider as supplied by the image crate _if_ `sic's` own image decider doesn't match an extension or identifier. The option can be enabled by providing the `--enable-output-format-decider-fallback` flag.


closes #362 