### PR TITLE
Refactor quotation mark trick for ImageFromPath: remove trick because it's unnecessary

### DIFF
--- a/components/sic_cli_ops/src/lib.rs
+++ b/components/sic_cli_ops/src/lib.rs
@@ -57,19 +57,7 @@ fn ast_from_index_tree(tree: &mut IndexTree) -> Result<Vec<Instr>, SicCliOpsErro
                 let empty: &[&str; 0] = &[];
                 id.mk_statement(empty)
             }
-            Op::WithValues(OperationId::Diff, values) => {
-                // HACK: From Pest we receive back a string including quotation marks, but
-                //       the terminal doesn't; we'll have to figure out how we can instruct Pest
-                //       to just give back the string contents without quotation marks
-                let mut values = values.to_vec();
-
-                #[allow(clippy::needless_range_loop)]
-                for i in 0..values.len() {
-                    values[i] = format!("\"{}\"", values[i]);
-                }
-
-                (OperationId::Diff).mk_statement(&values)
-            }
+            Op::WithValues(OperationId::Diff, values) => (OperationId::Diff).mk_statement(values),
             Op::WithValues(id, values) => id.mk_statement(values),
         })
         .collect::<Result<Vec<Instr>, SicCliOpsError>>()

--- a/components/sic_image_engine/src/errors.rs
+++ b/components/sic_image_engine/src/errors.rs
@@ -8,13 +8,6 @@ pub enum SicImageEngineError {
     #[error("unable to crop; anchor coordinates should be within image bounds [image size: (x={0}, y={1}), top-left anchor: (x={2}, y={3}), bottom-right anchor: (x={4}, y={5})]")]
     CropCoordinateOutOfBounds(u32, u32, u32, u32, u32, u32),
 
-    // FIXME 2020-02-08: Should capture the SicIoError like so:
-    //      LoadImageFromPath(sic_io::errors::SicIoError),
-    //      This however results in tons of "binary operation `!=` cannot be applied to type `sic_image_engine::errors::SicImageEngineError`"
-    //      errors, because in the sic_parsing tests we have assert_eq! tests against Result instead
-    //      of unwrapped results. Since this would be quite an effort and since these tests have to
-    //      be rewritten to make use of parameterized anyways, I left this as a fix me for later.
-    //      NOTE: Should also remove the derive(PartialEq, Eq) at that point!
     #[error("unable to load image argument from given path")]
     LoadImageFromPath,
 

--- a/components/sic_parser/src/errors.rs
+++ b/components/sic_parser/src/errors.rs
@@ -16,11 +16,14 @@ pub enum SicParserError {
     #[error("unable to parse named value: {0}")]
     NamedValueParsingError(NamedValueError),
 
-    #[error("unable to parse script: {0}")]
-    PestGrammarError(String),
+    #[error("string value expected an inner value, but none was found")]
+    NoInnerString,
 
     #[error("{0}")]
     OperationError(OperationParamError),
+
+    #[error("unable to parse script: {0}")]
+    PestGrammarError(String),
 
     #[error("parsing failed: operation doesn't exist")]
     UnknownOperationError,

--- a/components/sic_parser/src/rule_parser.rs
+++ b/components/sic_parser/src/rule_parser.rs
@@ -28,7 +28,11 @@ pub fn parse_image_operations(pairs: Pairs<'_, Rule>) -> Result<Vec<Instr>, SicP
             Rule::brighten => Brighten(pair),
             Rule::contrast => Contrast(pair),
             Rule::crop => Crop(pair),
-            Rule::diff => Diff(pair),
+            Rule::diff => Diff(
+                pair.into_inner()
+                    .next()
+                    .ok_or_else(|| SicParserError::NoInnerString)?,
+            ),
             Rule::filter3x3 => Filter3x3(pair),
             Rule::flip_horizontal => Ok(Instr::Operation(ImgOp::FlipHorizontal)),
             Rule::flip_vertical => Ok(Instr::Operation(ImgOp::FlipVertical)),

--- a/components/sic_parser/src/value_parser.rs
+++ b/components/sic_parser/src/value_parser.rs
@@ -236,13 +236,7 @@ impl ParseInputsFromIter for ImageFromPath {
             .map(Into::<Describable>::into)
             .ok_or_else(|| SicParserError::ValueParsingError(err_msg_no_such_element()))
             .and_then(|v: Describable| {
-                let len = v.0.len();
-
-                // TODO: this is unnecessary: this is necessary when using the outer rule 'string_unicode'
-                //  but we should use the inner rule 'string_inner', which spans just the text
-                let unquoted = &v.0[1..len - 1];
-
-                PathBuf::try_from(unquoted)
+                PathBuf::try_from(v.0)
                     .map_err(|_| SicParserError::ValueParsingError(err_msg_invalid_path()))
             })?;
 


### PR DESCRIPTION
- Trick was used because I (wrongly) thought I always received a string with quotation marks from my pest parser
- This was not true, I forgot to go one level deeper in the pairs iterator
- This PR removes the trick

closes #431 