### PR TITLE
Add draw-text image operation as cli operation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -781,6 +781,7 @@ version = "0.11.0"
 dependencies = [
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parameterized 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sic_core 0.11.0",
  "sic_image_engine 0.11.0",
  "sic_parser 0.11.0",
  "sic_testing 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ parameterized = "0.1.1"
 flate2 = "1.0.14"
 
 [features]
-imageproc-ops = ["sic_image_engine/imageproc-ops", "sic_parser/imageproc-ops"]
+imageproc-ops = ["sic_cli_ops/imageproc-ops", "sic_image_engine/imageproc-ops", "sic_parser/imageproc-ops"]
 
 output-test-images = []
 

--- a/components/sic_cli_ops/Cargo.toml
+++ b/components/sic_cli_ops/Cargo.toml
@@ -17,6 +17,7 @@ strum_macros = "0.18.0"
 thiserror = "1.0.19"
 
 [dev-dependencies]
+sic_core = { path = "../../components/sic_core" }
 sic_testing = { path = "../../components/sic_testing" }
 parameterized = "0.1.1"
 

--- a/components/sic_cli_ops/Cargo.toml
+++ b/components/sic_cli_ops/Cargo.toml
@@ -19,3 +19,6 @@ thiserror = "1.0.19"
 [dev-dependencies]
 sic_testing = { path = "../../components/sic_testing" }
 parameterized = "0.1.1"
+
+[features]
+imageproc-ops = []

--- a/components/sic_cli_ops/src/errors.rs
+++ b/components/sic_cli_ops/src/errors.rs
@@ -6,7 +6,7 @@ pub enum SicCliOpsError {
     #[error("Unable to parse: {0}")]
     ParserError(#[from] SicParserError),
 
-    #[error("Failed to parse value of type {typ} ({err})")]
+    #[error("Failed to parse value of type `{typ}`, error:\n\t{err}")]
     UnableToParseValueOfType { err: SicParserError, typ: String },
 
     #[error("Internal Error: {0}")]

--- a/components/sic_cli_ops/src/lib.rs
+++ b/components/sic_cli_ops/src/lib.rs
@@ -173,6 +173,43 @@ mod tests {
             assert_eq!(result.unwrap(), expected);
         }
 
+        #[cfg(feature = "imageproc-ops")]
+        mod imageproc_ops_tests {
+            use super::*;
+            use sic_core::image::Rgba;
+            use sic_image_engine::wrapper::draw_text_inner::DrawTextInner;
+            use sic_image_engine::wrapper::font_options::{FontOptions, FontScale};
+            use std::path::PathBuf;
+
+            ide!();
+
+            #[parameterized(
+                ops = {
+                    vec!["--draw-text", "my text", "coord(0, 1)", "rgba(10, 10, 255, 255)", "size(16.0)", r#"font("resources/font/Lato-Regular.ttf")"#],
+                    vec!["--draw-text", "my text", "coord(0, 1)", "rgba(10, 10, 255, 255)", "size(16.0)", r#"font("resources/font/Lato-Regular()".ttf")"#],
+                },
+                expected = {
+                    op![ImgOp::DrawText(DrawTextInner::new("my text".to_string(),
+                        (0, 1),
+                        FontOptions::new(
+                        PathBuf::from("resources/font/Lato-Regular.ttf".to_string()),
+                        Rgba([10, 10, 255, 255]),
+                        FontScale::Uniform(16.0))))],
+                    op![ImgOp::DrawText(DrawTextInner::new("my text".to_string(),
+                        (0, 1),
+                        FontOptions::new(
+                        PathBuf::from("resources/font/Lato-Regular()\".ttf".to_string()),
+                        Rgba([10, 10, 255, 255]),
+                        FontScale::Uniform(16.0))))]
+                }
+            )]
+            fn create_image_ops_t_sunny_imageproc_ops(ops: Vec<&str>, expected: Vec<Instr>) {
+                let result = create_image_ops(interweave(&ops));
+
+                assert_eq!(result.unwrap(), expected);
+            }
+        }
+
         #[test]
         fn combined() {
             let input = vec![

--- a/components/sic_cli_ops/src/operations.rs
+++ b/components/sic_cli_ops/src/operations.rs
@@ -21,6 +21,10 @@ pub enum OperationId {
     Contrast,
     Crop,
     Diff,
+
+    #[cfg(feature = "imageproc-ops")]
+    DrawText,
+
     Filter3x3,
     FlipHorizontal,
     FlipVertical,
@@ -64,6 +68,8 @@ impl OperationId {
             OperationId::Contrast => 1,
             OperationId::Crop => 4,
             OperationId::Diff => 1,
+            #[cfg(feature = "imageproc-ops")]
+            OperationId::DrawText => 5,
             OperationId::Filter3x3 => 9,
             OperationId::FlipHorizontal => 0,
             OperationId::FlipVertical => 0,
@@ -115,6 +121,10 @@ impl OperationId {
             )?)),
             OperationId::Diff => {
                 Instr::Operation(ImgOp::Diff(parse_inputs_by_type!(inputs, ImageFromPath)?))
+            }
+            #[cfg(feature = "imageproc-ops")]
+            OperationId::DrawText => {
+                unimplemented!();
             }
             OperationId::Filter3x3 => {
                 Instr::Operation(ImgOp::Filter3x3(parse_inputs_by_type!(inputs, [f32; 9])?))

--- a/components/sic_cli_ops/src/operations.rs
+++ b/components/sic_cli_ops/src/operations.rs
@@ -124,7 +124,11 @@ impl OperationId {
             }
             #[cfg(feature = "imageproc-ops")]
             OperationId::DrawText => {
-                unimplemented!();
+                use sic_image_engine::wrapper::draw_text_inner::DrawTextInner;
+                Instr::Operation(ImgOp::DrawText(parse_inputs_by_type!(
+                    inputs,
+                    DrawTextInner
+                )?))
             }
             OperationId::Filter3x3 => {
                 Instr::Operation(ImgOp::Filter3x3(parse_inputs_by_type!(inputs, [f32; 9])?))

--- a/components/sic_image_engine/src/engine.rs
+++ b/components/sic_image_engine/src/engine.rs
@@ -141,7 +141,11 @@ impl ImageEngine {
             }
 
             #[cfg(feature = "imageproc-ops")]
-            ImgOp::DrawText(text, coords, font_options) => {
+            ImgOp::DrawText(inner) => {
+                let text = inner.text();
+                let coords = inner.coords();
+                let font_options = inner.font_options();
+
                 use rusttype::Font;
 
                 let font_file = std::fs::read(&font_options.font_path)
@@ -157,7 +161,7 @@ impl ImageEngine {
                     coords.1,
                     font_options.scale,
                     &font,
-                    text.as_str(),
+                    text,
                 ));
 
                 Ok(())
@@ -1344,6 +1348,7 @@ mod tests {
     #[cfg(feature = "imageproc-ops")]
     mod imageproc_ops_tests {
         use super::*;
+        use crate::wrapper::draw_text_inner::DrawTextInner;
         use crate::wrapper::font_options::{FontOptions, FontScale};
 
         #[test]
@@ -1354,7 +1359,7 @@ mod tests {
             let font_file = Into::<PathBuf>::into(env!("CARGO_MANIFEST_DIR"))
                 .join("../../resources/font/Lato-Regular.ttf");
 
-            let operation = ImgOp::DrawText(
+            let operation = ImgOp::DrawText(DrawTextInner::new(
                 "HELLO WORLD".to_string(),
                 (0, 0),
                 FontOptions::new(
@@ -1362,7 +1367,7 @@ mod tests {
                     Rgba([255, 255, 0, 255]),
                     FontScale::Uniform(16.0),
                 ),
-            );
+            ));
 
             let mut operator = ImageEngine::new(img);
             let done = operator.ignite(&[Instr::Operation(operation)]);

--- a/components/sic_image_engine/src/lib.rs
+++ b/components/sic_image_engine/src/lib.rs
@@ -3,10 +3,9 @@
 #[macro_use]
 extern crate strum_macros;
 
-use crate::wrapper::image_path::ImageFromPath;
-
 #[cfg(feature = "imageproc-ops")]
-use wrapper::font_options::*;
+use crate::wrapper::draw_text_inner::DrawTextInner;
+use crate::wrapper::image_path::ImageFromPath;
 
 pub mod engine;
 pub mod errors;
@@ -32,5 +31,5 @@ pub enum ImgOp {
     Unsharpen((f32, i32)),
 
     #[cfg(feature = "imageproc-ops")]
-    DrawText(String, (u32, u32), FontOptions),
+    DrawText(DrawTextInner),
 }

--- a/components/sic_image_engine/src/wrapper/draw_text_inner.rs
+++ b/components/sic_image_engine/src/wrapper/draw_text_inner.rs
@@ -1,0 +1,32 @@
+#![cfg(feature = "imageproc-ops")]
+
+use crate::wrapper::font_options::FontOptions;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct DrawTextInner {
+    text: String,
+    coord: (u32, u32),
+    font_options: FontOptions,
+}
+
+impl DrawTextInner {
+    pub fn new(text: String, coord: (u32, u32), font_options: FontOptions) -> Self {
+        DrawTextInner {
+            text,
+            coord,
+            font_options,
+        }
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn coords(&self) -> (u32, u32) {
+        self.coord
+    }
+
+    pub fn font_options(&self) -> &FontOptions {
+        &self.font_options
+    }
+}

--- a/components/sic_image_engine/src/wrapper/mod.rs
+++ b/components/sic_image_engine/src/wrapper/mod.rs
@@ -3,3 +3,6 @@ pub mod image_path;
 
 #[cfg(feature = "imageproc-ops")]
 pub mod font_options;
+
+#[cfg(feature = "imageproc-ops")]
+pub mod draw_text_inner;

--- a/components/sic_io/src/conversion.rs
+++ b/components/sic_io/src/conversion.rs
@@ -269,10 +269,6 @@ mod tests {
                 .zip(EXPECTED_VALUES.iter());
 
             for ((ext, to_format), expected_format) in zipped {
-                println!(
-                    "testing `test_conversion_with_header_match`, converting {} => : {}",
-                    test_image, ext
-                );
                 test_conversion_with_header_match(test_image, ext, to_format, *expected_format)?;
             }
         }

--- a/components/sic_parser/src/errors.rs
+++ b/components/sic_parser/src/errors.rs
@@ -30,6 +30,9 @@ pub enum SicParserError {
 
     #[error("unable to parse value '{0}'")]
     ValueParsingError(String),
+
+    #[error("unable to parse value '{0}', error:\n\t{1}")]
+    ValueParsingErrorWithInnerError(String, Box<dyn std::error::Error + Send + Sync>),
 }
 
 #[derive(Debug, Error)]

--- a/components/sic_parser/src/grammar.pest
+++ b/components/sic_parser/src/grammar.pest
@@ -9,9 +9,12 @@ uint = @{ ASCII_DIGIT+ }
 int  = @{ "-"? ~ ASCII_DIGIT+ }
 
 // string_unicode is based on https://pest.rs/book/examples/json.html
-string_unicode = ${ (quotation ~ string_inner ~ quotation)* }
+string_unicode = ${ (quot_double ~ string_inner ~ quot_double) | (quot_single ~ string_inner ~ quot_single) }
 string_inner = @{ char* }
-quotation = _{ "'" | "\"" }
+quotation = _{ quot_single | quot_double }
+quot_single = _{ "'" }
+quot_double = _{ "\"" }
+
 char = {
     !quotation ~ ANY
     | "\\" ~ ("\"" | "\\" | "/" | "b" | "f" | "n" | "r" | "t")

--- a/components/sic_parser/src/rule_parser.rs
+++ b/components/sic_parser/src/rule_parser.rs
@@ -5,6 +5,8 @@ use crate::errors::{OperationParamError, SicParserError};
 use crate::value_parser::ParseInputsFromIter;
 use pest::iterators::{Pair, Pairs};
 use sic_image_engine::engine::{EnvItem, Instr, ItemName};
+#[cfg(feature = "imageproc-ops")]
+use sic_image_engine::wrapper::draw_text_inner::DrawTextInner;
 use sic_image_engine::wrapper::filter_type::FilterTypeWrap;
 use sic_image_engine::wrapper::image_path::ImageFromPath;
 use sic_image_engine::ImgOp;
@@ -184,7 +186,7 @@ fn parse_draw_text(pair: Pair<'_, Rule>) -> Result<Instr, SicParserError> {
 
     let font_file = parse_named_value(font_file).map_err(SicParserError::NamedValueParsingError)?;
 
-    Ok(Instr::Operation(ImgOp::DrawText(
+    Ok(Instr::Operation(ImgOp::DrawText(DrawTextInner::new(
         text_pair.to_string(),
         (coord.extract_coord()).map_err(SicParserError::NamedValueParsingError)?,
         FontOptions::new(
@@ -201,7 +203,7 @@ fn parse_draw_text(pair: Pair<'_, Rule>) -> Result<Instr, SicParserError> {
                     .map_err(SicParserError::NamedValueParsingError)?,
             ),
         ),
-    )))
+    ))))
 }
 
 #[cfg(test)]
@@ -1234,11 +1236,11 @@ mod tests {
                 FontScale::Uniform(16.0),
             );
 
-            let expected = vec![Instr::Operation(ImgOp::DrawText(
+            let expected = vec![Instr::Operation(ImgOp::DrawText(DrawTextInner::new(
                 "my text".to_string(),
                 (0, 1),
                 font_options,
-            ))];
+            )))];
             let actual = parse_image_operations(pairs).unwrap();
 
             assert_eq!(actual, expected);

--- a/components/sic_parser/src/rule_parser.rs
+++ b/components/sic_parser/src/rule_parser.rs
@@ -181,7 +181,7 @@ fn parse_draw_text(pair: Pair<'_, Rule>) -> Result<Instr, SicParserError> {
     let size = parse_named_value(size).map_err(SicParserError::NamedValueParsingError)?;
 
     let font_file = pairs.next().ok_or_else(|| {
-        SicParserError::ExpectedNamedValue(String::from("coord(font_path: String)"))
+        SicParserError::ExpectedNamedValue(String::from("font(font_path: String)"))
     })?;
 
     let font_file = parse_named_value(font_file).map_err(SicParserError::NamedValueParsingError)?;

--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -51,12 +51,32 @@ define_arg_consts!(arg_names, {
     GROUP_IMAGE_OPERATIONS,
 });
 
+#[cfg(not(feature = "imageproc-ops"))]
+fn wrap_with(app: App<'static, 'static>) -> App<'static, 'static> {
+    app
+}
+
+#[cfg(feature = "imageproc-ops")]
+fn wrap_with(app: App<'static, 'static>) -> App<'static, 'static> {
+    app.arg(
+        Arg::with_name(OperationId::DrawText.as_str())
+            .help("Operation: draw-text.")
+            .long(OperationId::DrawText.as_str())
+            .takes_value(true)
+            .value_name(
+                "<text> <coord(x, y)> <rgba(r,g,b,a)> <size(s)> <font(\"path/to/font.ttf\">)",
+            )
+            .number_of_values(5)
+            .multiple(true),
+    )
+}
+
 pub fn create_app(
     version: &'static str,
     about: &'static str,
     help_ops: &'static str,
 ) -> App<'static, 'static> {
-    App::new("sic")
+    wrap_with(App::new("sic")
         .version(version)
         .about(about)
         .after_help("For more information, visit: https://github.com/foresterre/sic")
@@ -214,6 +234,7 @@ pub fn create_app(
             .value_name("path to image")
             .number_of_values(1)
             .multiple(true))
+
         .arg(Arg::with_name(OperationId::Filter3x3.as_str())
             .help("Operation: filter3x3.")
             .long(OperationId::Filter3x3.as_str())
@@ -292,7 +313,7 @@ pub fn create_app(
             .number_of_values(1)
             .multiple(true)
             .possible_values(&["catmullrom", "gaussian", "lanczos3", "nearest", "triangle"])
-        )
+        ))
 }
 
 // Here any argument should not panic when invalid.

--- a/tests/cli_imageproc_ops.rs
+++ b/tests/cli_imageproc_ops.rs
@@ -16,7 +16,7 @@ mod tests {
             r#"draw-text "example" coord(0,1) rgba(0,0,0,255) size(24) font("%font%");"#,
         },
         output_file = {
-            "imageproc_ops_draw_text"
+            "imageproc_ops_draw_text_apply_operations"
         },
     )]
     fn check_imageproc_ops_with_script(ops: &str, output_file: &str) {
@@ -36,5 +36,53 @@ mod tests {
         let result = process.wait();
         assert!(result.is_ok());
         assert!(result.unwrap().success());
+    }
+
+    #[parameterized(
+        ops = {
+            &["--draw-text", "example", "coord(0,1)", "rgba(0,0,0,255)", "size(24)", "font('▲')"],
+            &["--draw-text", "example", "coord(0,1)", "rgba(0,0,0,255)", "size(24)", "font(\"▲\")"],
+            &["--draw-text", "example", "coord(0,1)", "rgba(0,0,0,255)", "size(24)", "font(\"▲\')"],
+        },
+        output_file = {
+            "imageproc_ops_draw_text_cli_arg_0_ok",
+            "imageproc_ops_draw_text_cli_arg_1_ok",
+            "imageproc_ops_draw_text_cli_arg_2_err",
+        },
+        ok = {
+            true,
+            true,
+            false,
+        }
+    )]
+    fn check_imageproc_ops_with_cli_args(ops: &[&str], output_file: &str, ok: bool) {
+        let font_file = &[
+            env!("CARGO_MANIFEST_DIR"),
+            "/resources/font/Lato-Regular.ttf",
+        ]
+        .concat();
+
+        let ops = ops
+            .iter()
+            .map(|v| v.replace('▲', font_file))
+            .collect::<Vec<_>>();
+
+        let ops = ops.iter().map(|v| v.as_str()).collect::<Vec<_>>();
+
+        let mut process = command_unsplit_with_features(
+            "unsplash_763569_cropped.jpg",
+            format!("{}.png", output_file).as_str(),
+            &ops,
+            &["imageproc-ops"],
+        );
+        let result = process.wait();
+        assert!(result.is_ok());
+        let result = result.unwrap();
+
+        if ok {
+            assert!(result.success());
+        } else {
+            assert!(!result.success());
+        }
     }
 }


### PR DESCRIPTION
Adds the `draw-text` operation to the cli ops parser. The operation and script parser for `draw-text [..]` have been implemented before, and can be found in #426  (issue #335). The syntax for the `draw-text` arguments will be equal to the syntax used by the script parser, i.e. `--draw-text 'example' 'coord(0,1)' 'rgba(0,0,0,255)' 'size(24)' font("<path>")`. 

closes #434 