### PR TITLE
Add publish package which should help with publishing workspace packages in topological order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b602bfe940d21c130f3895acd65221e8a61270debe89d628b9cb4e3ccb8569b"
 
 [[package]]
+name = "ascii"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab1c04a571841102f5345a8fc0f6bb3d31c315dec879b5c6e42e40ce7ffa34e"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -114,16 +120,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
+name = "cargo_metadata"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8de60b887edf6d74370fc8eb177040da4847d971d6234c7b13a6da324ef0caf"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2be76f06820200669a77ae59a8328c6b8fe4496e8fb7fed02f2806a442c5ff"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
-name = "clap"
-version = "2.33.1"
+name = "chrono"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "time",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
 dependencies = [
  "ansi_term",
  "atty",
@@ -139,6 +177,19 @@ name = "color_quant"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dbbb57365263e881e805dc77d94697c9118fd94d8da011240555aa7b23445bd"
+
+[[package]]
+name = "combine"
+version = "3.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3da6baa321ec19e1cc41d31bf599f00c783d0517095cdaf0332e3fe8d20680"
+dependencies = [
+ "ascii",
+ "byteorder",
+ "either",
+ "memchr",
+ "unreachable",
+]
 
 [[package]]
 name = "conv"
@@ -244,6 +295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "fixedbitset"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
+
+[[package]]
 name = "flate2"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +370,36 @@ dependencies = [
  "bitflags",
  "ignore",
  "walkdir",
+]
+
+[[package]]
+name = "guppy"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b59f0f3681219f7e2b91319819bd0ec0ec4a6a24e6bf0f4567ce27bea9ae2a4"
+dependencies = [
+ "cargo_metadata",
+ "fixedbitset",
+ "indexmap",
+ "itertools",
+ "nested",
+ "once_cell",
+ "pathdiff",
+ "petgraph",
+ "semver",
+ "serde",
+ "serde_json",
+ "supercow",
+ "target-spec",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f595585f103464d8d2f6e9864682d74c1601fed5e07d62b1c9058dba8246fb"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -387,6 +474,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b88cd59ee5f71fea89a62248fc8f387d44400cefe05ef548466d61ced9029a7"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "inflate"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -403,6 +500,12 @@ checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
 
 [[package]]
 name = "jpeg-decoder"
@@ -502,6 +605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nested"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b420f638f07fe83056b55ea190bb815f609ec5a35e7017884a10f78839c9e"
+
+[[package]]
 name = "num"
 version = "0.1.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +708,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -633,6 +748,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877630b3de15c0b64cc52f659345724fbf6bdad9bd9566699fc53688f3c34a34"
 
 [[package]]
 name = "pest"
@@ -678,6 +799,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
+dependencies = [
+ "fixedbitset",
+ "indexmap",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1eee8b1f4966c8343d7ca0f5a8452cd35d5610a2e0efbe2a68cae44bef2046"
+
+[[package]]
 name = "png"
 version = "0.16.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -702,6 +839,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "publish"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "guppy",
+ "pico-args",
+ "toml_edit",
 ]
 
 [[package]]
@@ -833,6 +981,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ryu"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -852,6 +1006,53 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "semver"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
+dependencies = [
+ "semver-parser",
+ "serde",
+]
+
+[[package]]
+name = "semver-parser"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "serde"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5317f7588f0a5078ee60ef675ef96735a1442132dc645eb1d12c018620ed8cd3"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.114"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164eacbdb13512ec2745fb09d51fd5b22b0d65ed294a1dcf7285a360c80a675c"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sha-1"
@@ -952,6 +1153,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+
+[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -976,6 +1183,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "supercow"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171758edb47aa306a78dfa4ab9aeb5167405bd4e3dc2b64e88f6a84bbe98bd63"
+
+[[package]]
 name = "syn"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -984,6 +1197,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "target-spec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "679ebfc4767de8af5cfc4c88b8a8c64025df29b0cede723bc40e1d4d2d851997"
+dependencies = [
+ "cfg-expr",
 ]
 
 [[package]]
@@ -1036,6 +1258,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09391a441b373597cf0888d2b052dcf82c5be4fee05da3636ae30fb57aad8484"
+dependencies = [
+ "chrono",
+ "combine",
+ "linked-hash-map",
+]
+
+[[package]]
 name = "ttf-parser"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,10 +1315,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+dependencies = [
+ "void",
+]
+
+[[package]]
 name = "vec_map"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
   "components/sic_io",
   "components/sic_parser",
   "components/sic_testing",
+  "publish"
 ]
 
 [dependencies]

--- a/components/sic_core/Cargo.toml
+++ b/components/sic_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sic_core"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 description = "Component of the sic cli: re-exports global dependencies to sub-crates."
 edition = "2018"

--- a/components/sic_testing/Cargo.toml
+++ b/components/sic_testing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sic_testing"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Martijn Gribnau <garm@ilumeo.com>"]
 description = "Component of the sic cli: provides commonly used testing operations for sic crates."
 edition = "2018"
@@ -8,5 +8,5 @@ license = "MIT"
 repository = "https://github.com/foresterre/sic"
 
 [dependencies]
-sic_core = { version = "0.12.0", path = "../sic_core" }
+sic_core = { version = "0.13.0", path = "../sic_core" }
 parameterized  = "0.2.0"

--- a/publish/Cargo.toml
+++ b/publish/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "publish"
+version = "0.1.0"
+authors = ["Martijn Gribnau <garm@ilumeo.com>"]
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.32"
+chrono = "0.4.13"
+guppy = "0.5.0"
+pico-args = "0.3.3"
+toml_edit = "0.2.0"

--- a/publish/src/backup.rs
+++ b/publish/src/backup.rs
@@ -1,0 +1,40 @@
+use anyhow::Context;
+use chrono::Utc;
+use std::path::{Path, PathBuf};
+
+pub(crate) fn backup_manifest(manifest: &Path) -> anyhow::Result<()> {
+    let folder = manifest
+        .parent()
+        .with_context(|| "manifest file has no parent")?;
+    let backup_folder = make_backup_folder(folder)?;
+
+    let name = backup_filename();
+    std::fs::copy(manifest, backup_folder.join(&name))?;
+
+    Ok(())
+}
+
+fn backup_filename() -> String {
+    let date_time = Utc::now();
+    let formatted_date_time = date_time.format("%F_%H-%M-%S_%6f").to_string();
+
+    format!("Cargo.toml.{}", formatted_date_time)
+}
+
+fn make_backup_folder(path: &Path) -> anyhow::Result<PathBuf> {
+    let backup_dir = path.join("backup");
+    let backup_dir = backup_dir.as_path();
+
+    if !backup_dir.exists() {
+        std::fs::create_dir_all(backup_dir)?;
+    }
+
+    if !backup_dir.is_dir() {
+        Err(anyhow::anyhow!(
+            "backup path exists but is not a directory..."
+        ))
+    } else {
+        std::fs::write(backup_dir.join(".gitignore"), "*")?;
+        Ok(backup_dir.to_path_buf())
+    }
+}

--- a/publish/src/commit.rs
+++ b/publish/src/commit.rs
@@ -1,0 +1,89 @@
+#![allow(unused)] // TODO!
+
+use std::path::Path;
+use std::process::Command;
+
+pub(crate) fn create_git(is_dry_run: bool, dir: &Path) -> Box<dyn GitCommit> {
+    if is_dry_run {
+        Box::new(DryRunGit::with_working_dir(dir))
+    } else {
+        Box::new(RegularRunGit::from_working_dir(dir))
+    }
+}
+
+pub(crate) trait GitCommit {
+    fn commit_package(&mut self, pkg_name: &str, version: &str);
+    fn run(&mut self) -> anyhow::Result<()>;
+}
+
+pub(crate) struct RegularRunGit {
+    command: Command,
+}
+
+impl RegularRunGit {
+    fn from_working_dir(dir: &Path) -> Self {
+        let mut command = Command::new("git");
+        command.current_dir(dir);
+
+        RegularRunGit { command }
+    }
+}
+
+impl GitCommit for RegularRunGit {
+    fn commit_package(&mut self, pkg_name: &str, version: &str) {
+        let message = commit_message(pkg_name, version);
+        self.command.args(&["commit", "-m", &message]);
+    }
+
+    fn run(&mut self) -> anyhow::Result<()> {
+        let child_process = self.command.spawn()?;
+        let result = child_process.wait_with_output()?;
+
+        anyhow::ensure!(
+            result.status.success(),
+            format!(
+                "Git command failed with stdout: {} and stderr: {}",
+                String::from_utf8_lossy(&result.stdout),
+                String::from_utf8_lossy(&result.stderr)
+            )
+        );
+
+        Ok(())
+    }
+}
+
+pub(crate) struct DryRunGit {
+    command: Command,
+}
+
+impl DryRunGit {
+    fn with_working_dir(dir: &Path) -> Self {
+        println!("git commit: using working dir: {}", dir.display());
+        let mut command = Command::new("git");
+        command.current_dir(dir);
+
+        Self { command }
+    }
+}
+
+impl GitCommit for DryRunGit {
+    fn commit_package(&mut self, pkg_name: &str, version: &str) {
+        println!(
+            "git commit: changes will be committed with message '{}'",
+            commit_message(pkg_name, version)
+        );
+
+        let message = commit_message(pkg_name, version);
+        self.command.args(&["commit", "--dry-run", "-m", &message]);
+    }
+
+    fn run(&mut self) -> anyhow::Result<()> {
+        println!("git commit: executing git command");
+
+        Ok(())
+    }
+}
+
+fn commit_message(pkg_name: &str, version: &str) -> String {
+    format!("sic publish: {}@{}", pkg_name, version)
+}

--- a/publish/src/main.rs
+++ b/publish/src/main.rs
@@ -1,0 +1,186 @@
+use crate::commit::create_git;
+use crate::publish_crate::create_publisher;
+use crate::update_dependents::create_dependent_updater;
+use crate::update_manifest::create_manifest_updater;
+use anyhow::Context;
+use guppy::graph::{DependencyDirection, PackageGraph, PackageLink, PackageMetadata};
+use guppy::MetadataCommand;
+use std::collections::{HashMap, HashSet};
+use std::ffi::OsString;
+use std::fmt::{Debug, Formatter};
+use std::hash::Hash;
+
+pub(crate) mod backup;
+pub(crate) mod commit;
+pub(crate) mod publish_crate;
+pub(crate) mod update_dependents;
+pub(crate) mod update_manifest;
+
+#[derive(Clone, Debug)]
+struct Args {
+    dry_run: bool,
+    manifest: OsString,
+    version: String,
+}
+
+// TODO to resolve:
+//  * error: failed to select a version for the requirement `sic_core = "^0.12.0"`
+//   candidate versions found which didn't match: 0.13.0
+//   location searched: \sic\components\sic_core
+//      required by package `sic_cli_ops v0.12.0 (\sic\components\sic_cli_ops)`
+//
+// TODO:
+//  * Copy to test repo so we can actually test against crates.io instead of doing dry-runs
+//
+// TODO:
+//  * resolve build graph for packages in workspace starting with name sic [x]
+//  * run script for each crate in order consisting of:
+//      * increment #version
+//      * commit
+//      * `cargo publish (--dry-run)`
+//      * set requirement of dependent crates to new #version
+//  * run post publish crate
+//      * set all versions to next -pre (e.g. 0.1.0-pre) at once
+//      * commit
+//
+// TODO improvements:
+//  * Instead of using name().starts_with("sic"), we could also use  pkg.in_workspace() and pkg.publish().is_some()
+//    which would make it re-usable for (my) projects outside sic =)
+fn main() -> anyhow::Result<()> {
+    let mut args = pico_args::Arguments::from_env();
+
+    let args = Args {
+        dry_run: args.contains("--dry-run"),
+        manifest: args
+            .opt_value_from_str("--manifest")?
+            .unwrap_or("Cargo.toml".into()),
+        version: args
+            .opt_value_from_str("--new-version")?
+            .with_context(|| "--new-version is required")?,
+    };
+
+    let mut cmd = MetadataCommand::new();
+    cmd.manifest_path(&args.manifest);
+
+    let graph = PackageGraph::from_command(&mut cmd)?;
+    let topological_workspace = graph.query_workspace();
+    let set = topological_workspace.resolve();
+
+    // topo sorted dependencies
+    let components_to_update = set
+        .packages(DependencyDirection::Reverse)
+        .filter(|pkg| pkg.name().starts_with("sic"));
+
+    // this is a collection of dependent packages. After updating the key package, its value members
+    // should update the key package version field to the new version of the key package
+    let dependants_db = set
+        .packages(DependencyDirection::Reverse)
+        .filter(|pkg| pkg.name().starts_with("sic"))
+        .fold(empty_map(), |mut map, dep| {
+            dep.direct_links()
+                .filter(|n| n.dep_name().starts_with("sic"))
+                .for_each(|link| {
+                    let set = map.entry(link.resolved_name()).or_default();
+
+                    set.insert(PackageWrapper::new(dep, link));
+                });
+
+            map
+        });
+
+    // TODO: create new git branch
+
+    publish_packages(
+        components_to_update,
+        &dependants_db,
+        &args.version,
+        args.dry_run,
+    )?;
+
+    Ok(())
+}
+
+fn empty_map<'a>() -> HashMap<&'a str, HashSet<PackageWrapper<'a>>> {
+    HashMap::new()
+}
+
+// Exists because PackageMetadata doesn't implement Hash
+struct PackageWrapper<'g> {
+    pkg_metadata: PackageMetadata<'g>,
+    link: PackageLink<'g>,
+}
+
+impl<'g> Debug for PackageWrapper<'g> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.pkg_metadata.name())
+    }
+}
+
+impl<'g> PackageWrapper<'g> {
+    pub(crate) fn new(package: PackageMetadata<'g>, link: PackageLink<'g>) -> Self {
+        Self {
+            pkg_metadata: package,
+            link,
+        }
+    }
+
+    pub(crate) fn metadata(&self) -> PackageMetadata<'g> {
+        self.pkg_metadata
+    }
+
+    pub(crate) fn link(&self) -> PackageLink<'g> {
+        self.link
+    }
+}
+
+impl<'g> Hash for PackageWrapper<'g> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.pkg_metadata.name().hash(state);
+    }
+}
+
+impl<'g> PartialEq for PackageWrapper<'g> {
+    fn eq(&self, other: &Self) -> bool {
+        self.pkg_metadata.name().eq(other.pkg_metadata.name())
+    }
+}
+
+impl<'g> Eq for PackageWrapper<'g> {}
+
+fn publish_packages<'g>(
+    components: impl Iterator<Item = PackageMetadata<'g>>,
+    dependents_db: &'g HashMap<&'g str, HashSet<PackageWrapper<'g>>>,
+    new_version: &str,
+    dry_run: bool,
+) -> anyhow::Result<()> {
+    // update workspace crates in topological order
+    for component in components {
+        let path = component.manifest_path();
+
+        let crate_folder = path.parent().with_context(|| {
+            format!(
+                "Expected parent folder for Cargo manifest at {}",
+                path.display()
+            )
+        })?;
+
+        // update the specific dependency
+        let manifest_updater = create_manifest_updater(dry_run, component);
+        manifest_updater.update_dependency_version(new_version)?;
+
+        // publish changes
+        let mut publisher = create_publisher(/*dry_run todo*/ true, component)?;
+        publisher.publish()?;
+
+        // update dependents to new version
+        let dependents_updater = create_dependent_updater(dry_run, dependents_db);
+        dependents_updater.update_all(component, new_version)?;
+
+        // commit changes
+        let mut command = create_git(/*dry_run todo*/ true, crate_folder);
+        command.commit_package(component.name(), new_version);
+        command.run()?;
+    }
+
+    Ok(())
+}

--- a/publish/src/publish_crate.rs
+++ b/publish/src/publish_crate.rs
@@ -1,0 +1,104 @@
+use anyhow::Context;
+use guppy::graph::PackageMetadata;
+use std::process::Command;
+
+pub(crate) fn create_publisher<'g>(
+    is_dry_run: bool,
+    pkg: PackageMetadata<'g>,
+) -> anyhow::Result<Box<dyn PublishPackage + 'g>> {
+    Ok(if is_dry_run {
+        Box::new(PublishDryRun::try_new(pkg)?)
+    } else {
+        Box::new(PublishOnCratesIO::try_new(pkg)?)
+    })
+}
+
+pub(crate) trait PublishPackage {
+    fn publish(&mut self) -> anyhow::Result<()>;
+}
+
+pub(crate) struct PublishOnCratesIO<'g> {
+    publisher: PublishImpl<'g>,
+}
+
+impl<'g> PublishOnCratesIO<'g> {
+    pub(crate) fn try_new(pkg: PackageMetadata<'g>) -> anyhow::Result<Self> {
+        Ok(Self {
+            publisher: PublishImpl::try_new(pkg, false)?,
+        })
+    }
+}
+
+impl PublishPackage for PublishOnCratesIO<'_> {
+    fn publish(&mut self) -> anyhow::Result<()> {
+        self.publisher.publish()
+    }
+}
+
+pub(crate) struct PublishDryRun<'g> {
+    publisher: PublishImpl<'g>,
+}
+
+impl<'g> PublishDryRun<'g> {
+    pub(crate) fn try_new(pkg: PackageMetadata<'g>) -> anyhow::Result<Self> {
+        Ok(Self {
+            publisher: PublishImpl::try_new(pkg, true)?,
+        })
+    }
+}
+
+impl PublishPackage for PublishDryRun<'_> {
+    fn publish(&mut self) -> anyhow::Result<()> {
+        self.publisher.publish()
+    }
+}
+
+struct PublishImpl<'g> {
+    command: Command,
+    pkg: PackageMetadata<'g>,
+}
+
+impl<'g> PublishImpl<'g> {
+    pub(crate) fn try_new(pkg: PackageMetadata<'g>, dry_run: bool) -> anyhow::Result<Self> {
+        let mut command = Command::new("cargo");
+        command.args(&[
+            "publish",
+            "--allow-dirty",
+            /* TODO remove */ "--no-verify",
+        ]);
+
+        if dry_run {
+            command.arg("--dry-run");
+        }
+
+        let from_directory = pkg.manifest_path().parent().with_context(|| {
+            format!(
+                "Expected parent folder for Cargo manifest at {}",
+                pkg.manifest_path().display()
+            )
+        })?;
+
+        command.current_dir(from_directory);
+
+        Ok(Self { command, pkg })
+    }
+}
+
+impl PublishPackage for PublishImpl<'_> {
+    fn publish(&mut self) -> anyhow::Result<()> {
+        let child_process = self.command.spawn()?;
+        let result = child_process.wait_with_output()?;
+
+        anyhow::ensure!(
+            result.status.success(),
+            format!(
+                "Cargo publish command failed for '{}' with stdout: {} and stderr: {}",
+                self.pkg.manifest_path().display(),
+                String::from_utf8_lossy(&result.stdout),
+                String::from_utf8_lossy(&result.stderr)
+            )
+        );
+
+        Ok(())
+    }
+}

--- a/publish/src/update_dependents.rs
+++ b/publish/src/update_dependents.rs
@@ -1,0 +1,97 @@
+use crate::backup::backup_manifest;
+use crate::PackageWrapper;
+use guppy::graph::PackageMetadata;
+use std::collections::{HashMap, HashSet};
+use toml_edit::{value, Document};
+
+pub(crate) fn create_dependent_updater<'g>(
+    is_dry_run: bool,
+    dependents_db: &'g HashMap<&'g str, HashSet<PackageWrapper<'g>>>,
+) -> Box<dyn UpdateDependents + 'g> {
+    if is_dry_run {
+        Box::new(DryRunUpdateDependents { dependents_db })
+    } else {
+        Box::new(RegularUpdateDependents { dependents_db })
+    }
+}
+
+pub(crate) trait UpdateDependents {
+    fn update_all<'g>(
+        &self,
+        updated_pkg: PackageMetadata<'g>,
+        new_version: &str,
+    ) -> anyhow::Result<()>;
+}
+
+pub(crate) struct RegularUpdateDependents<'g> {
+    dependents_db: &'g HashMap<&'g str, HashSet<PackageWrapper<'g>>>,
+}
+
+impl UpdateDependents for RegularUpdateDependents<'_> {
+    fn update_all<'gg>(
+        &self,
+        updated_pkg: PackageMetadata<'gg>,
+        new_version: &str,
+    ) -> anyhow::Result<()> {
+        if let Some(dependents) = self.dependents_db.get(updated_pkg.name()) {
+            for dependent in dependents {
+                update_dependent_manifest(dependent, new_version)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn update_dependent_manifest(dependent: &PackageWrapper<'_>, version: &str) -> anyhow::Result<()> {
+    let manifest = dependent.metadata().manifest_path();
+    let cargo_file = std::fs::read_to_string(manifest)?;
+    let mut document = cargo_file.parse::<Document>()?;
+
+    backup_manifest(manifest)?;
+
+    let dependency = dependent.link().resolved_name();
+
+    if dependent.link().normal().is_present() {
+        document["dependencies"][dependency]["version"] = value(version);
+    }
+
+    if dependent.link().dev().is_present() {
+        document["dev-dependencies"][dependency]["version"] = value(version);
+    }
+
+    if dependent.link().build().is_present() {
+        document["build-dependencies"][dependency]["version"] = value(version);
+    }
+
+    std::fs::write(manifest, document.to_string_in_original_order())?;
+
+    Ok(())
+}
+
+pub(crate) struct DryRunUpdateDependents<'g> {
+    dependents_db: &'g HashMap<&'g str, HashSet<PackageWrapper<'g>>>,
+}
+
+impl UpdateDependents for DryRunUpdateDependents<'_> {
+    fn update_all<'g>(
+        &self,
+        updated_pkg: PackageMetadata<'g>,
+        new_version: &str,
+    ) -> anyhow::Result<()> {
+        if let Some(dependents) = self.dependents_db.get(updated_pkg.name()) {
+            println!("update-dependents: updating dependency '{}' to '{}' for packages in workspace which depend on it {:?}", updated_pkg.name(), new_version, dependents);
+
+            for dependent in dependents {
+                println!(
+                    "update-dependents: dependency '{}' will be updated to '{}' for '{}'",
+                    updated_pkg.name(),
+                    new_version,
+                    dependent.metadata().name(),
+                )
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/publish/src/update_manifest.rs
+++ b/publish/src/update_manifest.rs
@@ -1,0 +1,59 @@
+use crate::backup::backup_manifest;
+use guppy::graph::PackageMetadata;
+use std::path::Path;
+use toml_edit::value;
+
+pub(crate) fn create_manifest_updater<'g>(
+    is_dry_run: bool,
+    pkg: PackageMetadata<'g>,
+) -> Box<dyn UpdateManifest + 'g> {
+    if is_dry_run {
+        Box::new(DryRunManifestUpdate { pkg })
+    } else {
+        Box::new(RegularManifestUpdate { pkg })
+    }
+}
+
+pub(crate) trait UpdateManifest {
+    fn update_dependency_version(&self, new_version: &str) -> anyhow::Result<()>;
+}
+
+pub(crate) struct RegularManifestUpdate<'g> {
+    pkg: PackageMetadata<'g>,
+}
+
+impl UpdateManifest for RegularManifestUpdate<'_> {
+    fn update_dependency_version(&self, new_version: &str) -> anyhow::Result<()> {
+        backup_manifest(self.pkg.manifest_path())?;
+        toml_update(self.pkg.manifest_path(), new_version)?;
+
+        Ok(())
+    }
+}
+
+pub(crate) struct DryRunManifestUpdate<'g> {
+    pkg: PackageMetadata<'g>,
+}
+
+impl UpdateManifest for DryRunManifestUpdate<'_> {
+    fn update_dependency_version(&self, new_version: &str) -> anyhow::Result<()> {
+        println!(
+            "update-manifest: updating crate '{}' manifest version to '{}'",
+            self.pkg.name(),
+            new_version
+        );
+
+        Ok(())
+    }
+}
+
+fn toml_update(manifest: &Path, new_version: &str) -> anyhow::Result<()> {
+    let contents = std::fs::read_to_string(manifest)?;
+
+    let mut document = contents.parse::<toml_edit::Document>()?;
+    document["package"]["version"] = value(new_version);
+
+    std::fs::write(manifest, document.to_string_in_original_order())?;
+
+    Ok(())
+}


### PR DESCRIPTION
Should be nearly minimal-viable-product ready except for one issue where crates with a path and a version do no longer resolve after updating the version. Perhaps to workaround this remove the path; update; re-add the path?