### PR TITLE
Remove AVIF ImageOutputFormat hack

### DIFF
--- a/components/sic_io/src/conversion.rs
+++ b/components/sic_io/src/conversion.rs
@@ -2,7 +2,6 @@ use crate::errors::SicIoError;
 use image::buffer::ConvertBuffer;
 use image::DynamicImage;
 use sic_core::image;
-use sic_core::image::GenericImageView;
 use std::io::Write;
 
 #[derive(Clone, Copy, Debug)]
@@ -45,24 +44,7 @@ impl<'a> ConversionWriter<'a> {
             None => &self.image,
         };
 
-        // FIXME remove: https://github.com/foresterre/sic/issues/597
-        if std::env::var("SIC_AVIF_HACK").is_ok() {
-            let avif_encoder = image::avif::AvifEncoder::new(writer);
-            avif_encoder
-                .write_image(
-                    &export_buffer.to_bytes(),
-                    export_buffer.width(),
-                    export_buffer.height(),
-                    export_buffer.color(),
-                )
-                .map_err(SicIoError::ImageError)?;
-
-            std::env::remove_var("SIC_AVIF_HACK");
-
-            Ok(())
-        } else {
-            ConversionWriter::save_to(writer, &export_buffer, output_format)
-        }
+        ConversionWriter::save_to(writer, &export_buffer, output_format)
     }
 
     /// Some image output format types require color type pre-processing.

--- a/components/sic_io/src/format.rs
+++ b/components/sic_io/src/format.rs
@@ -86,12 +86,7 @@ impl EncodingFormatByIdentifier for DetermineEncodingFormat {
     /// Identifiers are based on common output file extensions.
     fn by_identifier(&self, identifier: &str) -> Result<image::ImageOutputFormat, SicIoError> {
         match identifier.to_ascii_lowercase().as_str() {
-            "avif" => {
-                // FIXME: Dirty hack
-                //  - https://github.com/foresterre/sic/issues/597
-                std::env::set_var("SIC_AVIF_HACK", "1");
-                Ok(image::ImageOutputFormat::Farbfeld)
-            }
+            "avif" => Ok(image::ImageOutputFormat::Avif),
             "bmp" => Ok(image::ImageOutputFormat::Bmp),
             "farbfeld" => Ok(image::ImageOutputFormat::Farbfeld),
             "gif" => Ok(image::ImageOutputFormat::Gif),
@@ -149,12 +144,12 @@ mod tests {
     use super::*;
 
     const INPUT_FORMATS: &[&str] = &[
-        //"avif",
-        "bmp", "farbfeld", "gif", "ico", "jpg", "jpeg", "png", "pbm", "pgm", "ppm", "pam", "tga",
+        "avif", "bmp", "farbfeld", "gif", "ico", "jpg", "jpeg", "png", "pbm", "pgm", "ppm", "pam",
+        "tga",
     ];
 
     const EXPECTED_VALUES: &[image::ImageOutputFormat] = &[
-        // image::ImageOutputFormat::Avif,
+        image::ImageOutputFormat::Avif,
         image::ImageOutputFormat::Bmp,
         image::ImageOutputFormat::Farbfeld,
         image::ImageOutputFormat::Gif,


### PR DESCRIPTION
Now ImageOutputFormat support for AVIF was incorporated by image, and we updated our image dependency version, we don't need this hack anymore.