### PR TITLE
Fix Rust 1.50 linter issues

### DIFF
--- a/components/sic_image_engine/src/engine.rs
+++ b/components/sic_image_engine/src/engine.rs
@@ -102,8 +102,14 @@ impl ImageEngine {
     fn process_instruction(&mut self, instruction: &Instr) -> Result<(), SicImageEngineError> {
         match instruction {
             Instr::Operation(op) => self.process_operation(op),
-            Instr::EnvAdd(item) => self.insert_env(*item),
-            Instr::EnvRemove(key) => self.remove_env(*key),
+            Instr::EnvAdd(item) => {
+                self.insert_env(*item);
+                Ok(())
+            }
+            Instr::EnvRemove(key) => {
+                self.remove_env(*key);
+                Ok(())
+            }
         }
     }
 
@@ -135,7 +141,7 @@ impl ImageEngine {
             }
             ImgOp::Diff(img) => {
                 let other = img.open_image()?;
-                *self.image = produce_image_diff(&self.image, &other)?;
+                *self.image = produce_image_diff(&self.image, &other);
 
                 Ok(())
             }
@@ -235,13 +241,11 @@ impl ImageEngine {
         }
     }
 
-    fn insert_env(&mut self, item: EnvItem) -> Result<(), SicImageEngineError> {
+    fn insert_env(&mut self, item: EnvItem) {
         self.environment.insert_or_update(item);
-
-        Ok(())
     }
 
-    fn remove_env(&mut self, key: ItemName) -> Result<(), SicImageEngineError> {
+    fn remove_env(&mut self, key: ItemName) {
         let success = self.environment.remove(key);
 
         if success.is_none() {
@@ -250,8 +254,6 @@ impl ImageEngine {
                 key
             );
         }
-
-        Ok(())
     }
 }
 
@@ -277,10 +279,7 @@ const DIFF_PX_NO_OVERLAP: Rgba<u8> = Rgba([0, 0, 0, 0]);
 /// That is, the part of output image which isn't part of either of the two original input images.
 /// These pixels will be 'coloured' black but with an alpha value of 0, so they will be transparent
 /// as to show they were not part of the input images.
-fn produce_image_diff(
-    this: &DynamicImage,
-    other: &DynamicImage,
-) -> Result<DynamicImage, SicImageEngineError> {
+fn produce_image_diff(this: &DynamicImage, other: &DynamicImage) -> DynamicImage {
     let (lw, lh) = this.dimensions();
     let (rw, rh) = other.dimensions();
 
@@ -303,7 +302,7 @@ fn produce_image_diff(
         }
     }
 
-    Ok(DynamicImage::ImageRgba8(buffer))
+    DynamicImage::ImageRgba8(buffer)
 }
 
 struct CropSelection {

--- a/components/sic_parser/src/named_value.rs
+++ b/components/sic_parser/src/named_value.rs
@@ -141,7 +141,7 @@ impl<'a> Value<'a> {
             (Rule::fp, Ident::Rgba) => Ok(Value::parse_byte(pair.as_str())?),
             (Rule::fp, Ident::Size) => Ok(Value::parse_float(pair.as_str())?),
             (Rule::fp, Ident::Coord) => Ok(Value::parse_nat_num(pair.as_str())?),
-            (Rule::string_unicode, _) => Ok(Value::parse_string(pair.into_inner().as_str())?),
+            (Rule::string_unicode, _) => Ok(Value::parse_string(pair.into_inner().as_str())),
             _ => Err(NamedValueError::InvalidArgumentType),
         }
     }
@@ -151,7 +151,7 @@ impl<'a> Value<'a> {
             Ident::Rgba => Ok(Value::parse_byte(s)?),
             Ident::Size => Ok(Value::parse_float(s)?),
             Ident::Coord => Ok(Value::parse_nat_num(s)?),
-            Ident::Font => Ok(Value::parse_string(slice_str_tokens(s)?)?),
+            Ident::Font => Ok(Value::parse_string(slice_str_tokens(s)?)),
         }
     }
 
@@ -230,8 +230,8 @@ impl<'a> Value<'a> {
         })
     }
 
-    fn parse_string(value: &'a str) -> NVResult<Self> {
-        Ok(Value::String(value))
+    fn parse_string(value: &'a str) -> Self {
+        Value::String(value)
     }
 
     fn error_type(&self) -> String {

--- a/tasks/publish/src/pipeline/update_dependents.rs
+++ b/tasks/publish/src/pipeline/update_dependents.rs
@@ -37,10 +37,12 @@ impl Action for UpdateDependents<'_, '_> {
 
         // if we perform a dry run, we should not actually update the manifests
         if args.dry_run {
-            dry_update_all(self.dependents_db, self.updated_pkg, version)
+            dry_update_all(self.dependents_db, self.updated_pkg, version);
         } else {
-            live_update_all(self.dependents_db, self.updated_pkg, version)
+            live_update_all(self.dependents_db, self.updated_pkg, version)?;
         }
+
+        Ok(())
     }
 }
 
@@ -89,7 +91,7 @@ fn dry_update_all<'g>(
     dependents_db: &'g DependentsDB<'g>,
     updated_pkg: &'g PackageMetadata<'g>,
     new_version: &str,
-) -> anyhow::Result<()> {
+) {
     if let Some(dependents) = dependents_db.get(updated_pkg.name()) {
         println!("update-dependents: updating dependency '{}' to '{}' for packages in workspace which depend on it {:?}", updated_pkg.name(), new_version, dependents);
 
@@ -102,6 +104,4 @@ fn dry_update_all<'g>(
             )
         }
     }
-
-    Ok(())
 }

--- a/tests/cli_convert.rs
+++ b/tests/cli_convert.rs
@@ -323,7 +323,6 @@ fn convert_jpeg_quality_different() {
     let contents1 = read_file_to_bytes(path_buf_str(&out1));
     let contents2 = read_file_to_bytes(path_buf_str(&out2));
 
-    assert_eq!(contents1, contents1);
     assert_ne!(contents1, contents2);
 
     clean_up_output_path(path_buf_str(&out1));

--- a/tests/cli_image_operation_args.rs
+++ b/tests/cli_image_operation_args.rs
@@ -11,7 +11,7 @@ fn command(input: &str, output: &str, args: &str) -> Child {
     common::SicTestCommandBuilder::new()
         .input_from_resources(input)
         .output_in_target(output)
-        .with_args(args.split(" "))
+        .with_args(args.split(' '))
         .spawn_child()
 }
 


### PR DESCRIPTION
Clippy for Rust 1.50 seems to have introduced a new 'unnecessary wraps' lint (although I don't think this lint improves the readability of the code, )

relevant issues:
* https://github.com/rust-lang/rust-clippy/issues/6721
* https://github.com/rust-lang/rust-clippy/issues/6726