### PR TITLE
Fix Rust 1.50 linter issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,7 +200,7 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features --workspace
+          args: --all-features --all-targets --workspace
       - name: check_with_clippy_task_pack_release
         uses: actions-rs/clippy-check@v1
         with:

--- a/components/sic_image_engine/src/lib.rs
+++ b/components/sic_image_engine/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::unnecessary_wraps)]
 
 #[macro_use]
 extern crate strum_macros;

--- a/components/sic_parser/src/lib.rs
+++ b/components/sic_parser/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::unnecessary_wraps)]
 
 #[macro_use]
 extern crate pest_derive;

--- a/tasks/publish/src/main.rs
+++ b/tasks/publish/src/main.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::unnecessary_wraps)]
 
 use std::collections::{HashMap, HashSet};
 

--- a/tests/cli_convert.rs
+++ b/tests/cli_convert.rs
@@ -323,7 +323,6 @@ fn convert_jpeg_quality_different() {
     let contents1 = read_file_to_bytes(path_buf_str(&out1));
     let contents2 = read_file_to_bytes(path_buf_str(&out2));
 
-    assert_eq!(contents1, contents1);
     assert_ne!(contents1, contents2);
 
     clean_up_output_path(path_buf_str(&out1));

--- a/tests/cli_glob.rs
+++ b/tests/cli_glob.rs
@@ -1,4 +1,3 @@
-#[allow(unused)]
 #[macro_use]
 pub mod common;
 

--- a/tests/cli_image_operation_args.rs
+++ b/tests/cli_image_operation_args.rs
@@ -11,7 +11,7 @@ fn command(input: &str, output: &str, args: &str) -> Child {
     common::SicTestCommandBuilder::new()
         .input_from_resources(input)
         .output_in_target(output)
-        .with_args(args.split(" "))
+        .with_args(args.split(' '))
         .spawn_child()
 }
 


### PR DESCRIPTION
We explicitly allow the newly enabled clippy::unnecessary_wraps lint. Although the lint has good intentions, we disable it because it decreases code readability of the caller functions.

relevant issues:
* https://github.com/rust-lang/rust-clippy/issues/6726
* https://github.com/rust-lang/rust-clippy/issues/6721