### PR TITLE
Allow the upper_case_acronyms lint

### DIFF
--- a/components/sic_cli_ops/src/lib.rs
+++ b/components/sic_cli_ops/src/lib.rs
@@ -73,6 +73,7 @@ fn take_n<I: Iterator<Item = String>>(
 mod tests {
     use super::*;
 
+    #[allow(clippy::vec_init_then_push)]
     mod individual_args {
         use super::*;
         use sic_image_engine::engine::EnvItem;

--- a/components/sic_io/src/lib.rs
+++ b/components/sic_io/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![allow(clippy::upper_case_acronyms)]
 
 // importing
 pub mod load;

--- a/components/sic_parser/src/lib.rs
+++ b/components/sic_parser/src/lib.rs
@@ -1,5 +1,5 @@
 #![deny(clippy::all)]
-#![allow(clippy::unnecessary_wraps)]
+#![allow(clippy::unnecessary_wraps, clippy::upper_case_acronyms)]
 
 #[macro_use]
 extern crate pest_derive;


### PR DESCRIPTION
This lint was added in Rust Clippy v1.51, but requires changes in public API's. This isn't a huge problem for `sic`, but whether this lint is good or not is an opinionated affair which I don't want to dip into right now.