### PR TITLE
Add the two `time` rustsec advisories to the exception list

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,4 +30,11 @@ ignore = [
     "RUSTSEC-2020-0023",
     # rulinalg crate is no longer maintained
     "RUSTSEC-2020-0147",
+
+    # Potential segfault in the time crate
+    # NB: has been fixed in time >=0.2.23, however waiting on chrono crate to update
+    # chrono PR: https://github.com/chronotope/chrono/pull/578
+    "RUSTSEC-2020-0071",
+    # Potential segfault in localtime_r invocations, see 2020-0071
+    "RUSTSEC-2020-0159",
 ]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -101,8 +101,8 @@ impl SicTestCommandBuilder {
         command.args(self.commands);
 
         command
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
             .spawn()
             .map_err(|err| {
                 eprintln!(


### PR DESCRIPTION
* We're waiting for chrono to update
* We may want to update to time 0.3, and have this replace chrono
* Presumably very difficult to exploit the vulnerability, so not too high a risk