### PR TITLE
Switch imageproc from patched version to official version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,10 +601,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "imageproc-patched"
-version = "0.22.0-unofficial.1-foresterre"
+name = "imageproc"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be70accd92e538a732e8c5f5d9e5d89801af086563c90049c6bbc4860a943a9c"
+checksum = "b6aee993351d466301a29655d628bfc6f5a35a0d062b6160ca0808f425805fd7"
 dependencies = [
  "approx",
  "conv",
@@ -1468,7 +1468,7 @@ name = "sic_core"
 version = "0.20.0"
 dependencies = [
  "image",
- "imageproc-patched",
+ "imageproc",
  "rusttype",
  "thiserror",
 ]

--- a/components/sic_core/Cargo.toml
+++ b/components/sic_core/Cargo.toml
@@ -13,10 +13,10 @@ rust-version = "1.56"
 [dependencies]
 image = { version = "0.24.2", features = ["avif"] }
 
-imageproc-patched = { version = "0.22.0-unofficial.1-foresterre", optional = true }
+imageproc = { version = "0.23.0", optional = true }
 rusttype = { version = "0.9.2", optional = true }
 
 thiserror = "1.0.31"
 
 [features]
-imageproc-ops = ["imageproc-patched", "rusttype"]
+imageproc-ops = ["imageproc", "rusttype"]

--- a/components/sic_core/src/lib.rs
+++ b/components/sic_core/src/lib.rs
@@ -9,7 +9,7 @@
 pub use image;
 
 #[cfg(feature = "imageproc-ops")]
-pub use {imageproc_patched as imageproc, rusttype};
+pub use {imageproc, rusttype};
 
 use crate::errors::SicCoreError;
 


### PR DESCRIPTION
Now that the official imageproc version compatible with image 0.24 has been published to crates.io, we can switch back to the official version of imageproc for future updates.