### PR TITLE
Allow unmaintained crate ansi_term for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,4 +32,6 @@ ignore = [
     "RUSTSEC-2020-0071",
     # Potential segfault in localtime_r invocations, see 2020-0071
     "RUSTSEC-2020-0159",
+    # unmaintained crate ansi_term
+    "RUSTSEC-2021-0139",
 ]


### PR DESCRIPTION
There are no known vulnerabilities, and the dependency is not doing magic, so
until it has been replaced down-tree (there's an open PR for a few days), it should
be find, and non-blocking. To be revisited after it has been patched out down-tree.