### PR TITLE
Rusttype is unmaintained

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -34,4 +34,6 @@ ignore = [
     "RUSTSEC-2020-0159",
     # unmaintained crate ansi_term
     "RUSTSEC-2021-0139",
+    # unmaintained crate rusttype
+    "RUSTSEC-2021-0140",
 ]


### PR DESCRIPTION
- No known security issues
- Requires update from imageproc. no patch yet
- ab_glyph replacement is available