### PR TITLE
Fix issue where image could not be loaded from stdin

### DIFF
--- a/src/cli/app.rs
+++ b/src/cli/app.rs
@@ -399,7 +399,7 @@ pub fn build_app_config<'a>(matches: &'a ArgMatches) -> anyhow::Result<Config<'a
         return Ok(builder.build());
     }
 
-    builder = builder.mode(InputOutputModeType::from_arg_matches(matches)?);
+    builder = builder.mode(InputOutputModeType::from_arg_matches(matches));
 
     // config(in)/select-frame:
     if let Some(value) = matches.value_of(ARG_SELECT_FRAME) {

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -27,6 +27,7 @@ impl PathVariant {
     }
 }
 
+#[derive(Debug)]
 pub enum InputOutputMode {
     Single {
         input: PathVariant,
@@ -40,7 +41,7 @@ pub enum InputOutputMode {
 
 impl InputOutputMode {
     pub fn try_from_matches(matches: &ArgMatches) -> anyhow::Result<Self> {
-        let mode = InputOutputModeType::from_arg_matches(matches)?;
+        let mode = InputOutputModeType::from_arg_matches(matches);
 
         match mode {
             InputOutputModeType::Simple => Ok(InputOutputMode::Single {
@@ -140,19 +141,12 @@ pub enum InputOutputModeType {
 }
 
 impl InputOutputModeType {
-    pub fn from_arg_matches(matches: &ArgMatches) -> anyhow::Result<InputOutputModeType> {
-        Ok(
-            match (
-                matches.is_present(ARG_INPUT),
-                matches.is_present(ARG_INPUT_GLOB),
-            ) {
-                (true, false) => InputOutputModeType::Simple,
-                (false, true) => InputOutputModeType::Batch,
-                _ => {
-                    bail!("Unable select input/output mode: mode should either be simple xor glob")
-                }
-            },
-        )
+    pub fn from_arg_matches(matches: &ArgMatches) -> InputOutputModeType {
+        if matches.is_present(ARG_INPUT_GLOB) {
+            InputOutputModeType::Batch
+        } else {
+            InputOutputModeType::Simple
+        }
     }
 }
 


### PR DESCRIPTION
Previously we would explicitly require the --input or --glob-input argument to be present, for the input mode to be selected (batch or single file input and output).

Now we instead check if --glob-input is present, and if it is select batch mode, otherwise we always select 'simple' mode (i.e. single input and output). NB: this also means that stdin should always use single input and output.

fixes #1398 