### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1221,14 +1221,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pack-release"
-version = "0.20.0"
-dependencies = [
- "xshell",
- "zip",
-]
-
-[[package]]
 name = "parameterized"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2451,37 +2443,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "xshell"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962c039b3a7b16cf4e9a4248397c6585c07547412e7d6a6e035389a802dcfe90"
-dependencies = [
- "xshell-macros",
-]
-
-[[package]]
-name = "xshell-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbabb1cbd15a1d6d12d9ed6b35cc6777d4af87ab3ba155ea37215f20beab80c"
-
-[[package]]
 name = "y4m"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a72a9921af8237fe25097a1ae31c92a05c1d39b2454653ad48f2f407cf7a0dae"
-
-[[package]]
-name = "zip"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
-]
 
 [[package]]
 name = "zune-inflate"


### PR DESCRIPTION
I got the following error while building the [AUR package](https://aur.archlinux.org/packages/sic-image-cli-git):

```
==> Starting prepare()...
    Updating crates.io index
error: the lock file /build/sic-image-cli-git/src/sic/Cargo.lock needs to be updated but --locked was passed to prevent this
If you want to try to generate the lock file without accessing the network, remove the --locked flag and use --offline instead.
```

It is due to using `--locked` which is required for reproducible builds.

This PR simply updates `Cargo.lock` based on the latest state of the dependencies thus fixes this issue.
