### PR TITLE
Add image feature avif-native

### DIFF
--- a/.github/actions/setup-dav1d/action.yml
+++ b/.github/actions/setup-dav1d/action.yml
@@ -1,0 +1,47 @@
+name: "setup-dav1d"
+description: "Install build prerequisites, build a static libdav1d from source, and expose it to the build."
+
+inputs:
+  setup-msvc:
+    description: "Set up the MSVC developer environment, required for meson on the windows-msvc target. Disable for the windows-gnu target."
+    required: false
+    default: "true"
+
+runs:
+  using: "composite"
+  steps:
+    - name: install_just
+      uses: extractions/setup-just@v2
+
+    - name: setup_msvc
+      if: runner.os == 'Windows' && inputs.setup-msvc == 'true'
+      uses: ilammy/msvc-dev-cmd@v1
+
+    - name: install_dav1d_prerequisites
+      shell: bash
+      run: just install-dav1d-prerequisites
+
+    - name: add_nasm_to_path
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: Add-Content -Path $env:GITHUB_PATH -Value "$env:LOCALAPPDATA\Microsoft\WinGet\Links"
+
+    - name: install_dav1d
+      shell: bash
+      run: just install-dav1d
+
+    - name: expose_dav1d_unix
+      if: runner.os != 'Windows'
+      shell: bash
+      run: echo "PKG_CONFIG_PATH=${GITHUB_WORKSPACE}/target/dav1d/lib/pkgconfig${PKG_CONFIG_PATH:+:${PKG_CONFIG_PATH}}" >> "$GITHUB_ENV"
+
+    - name: expose_dav1d_windows
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $prefix = "$env:GITHUB_WORKSPACE\target\dav1d"
+        Add-Content -Path $env:GITHUB_ENV -Value "SYSTEM_DEPS_DAV1D_NO_PKG_CONFIG=1"
+        Add-Content -Path $env:GITHUB_ENV -Value "SYSTEM_DEPS_DAV1D_SEARCH_NATIVE=$prefix\lib"
+        Add-Content -Path $env:GITHUB_ENV -Value "SYSTEM_DEPS_DAV1D_INCLUDE=$prefix\include"
+        Add-Content -Path $env:GITHUB_ENV -Value "SYSTEM_DEPS_DAV1D_LIB=dav1d"
+        Add-Content -Path $env:GITHUB_ENV -Value "SYSTEM_DEPS_LINK=static"

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -56,27 +56,12 @@ jobs:
       - name: install_rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: install_nasm
-        if: matrix.target != 'x86_64-pc-windows-msvc'
-        uses: ilammy/setup-nasm@v1
-
-      - name: install_nasm_msvc
-        if: matrix.target == 'x86_64-pc-windows-msvc'
-        run: |
-          $NASM_VERSION="2.15.05"
-          $LINK = "https://www.nasm.us/pub/nasm/releasebuilds/$NASM_VERSION/win64"
-          $NASM_FILE = "nasm-$NASM_VERSION-win64"
-          curl --ssl-no-revoke -LO "$LINK/$NASM_FILE.zip"
-          7z e -y "$NASM_FILE.zip" -o"C:\nasm"
-          echo "C:\nasm"  | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          $LinkGlob = "VC\Tools\MSVC\*\bin\Hostx64\x64"
-          $env:PATH = "$env:PATH;${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer"
-          $LinkPath = vswhere -latest -products * -find "$LinkGlob" | Select-Object -Last 1
-          echo "$LinkPath" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: setup_dav1d
+        uses: ./.github/actions/setup-dav1d
 
       - name: build_${{ matrix.target }}_release_binary
         shell: bash
-        run: cargo build --target=${{ matrix.target }} --release
+        run: cargo build --target=${{ matrix.target }} --release --features avif-decoder
 
       - name: install_cargo_about
         shell: bash

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -18,8 +18,8 @@ jobs:
         with:
           components: clippy
 
-      - name: install_nasm
-        uses: ilammy/setup-nasm@v1
+      - name: setup_dav1d
+        uses: ./.github/actions/setup-dav1d
 
       - name: clippy
         run: cargo clippy --all-targets --all-features --workspace

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -25,8 +25,8 @@ jobs:
       - name: version_of_cargo_msrv
         run: cargo msrv --version
 
-      - name: install_nasm
-        uses: ilammy/setup-nasm@v1
+      - name: setup_dav1d
+        uses: ./.github/actions/setup-dav1d
 
       - name: run_cargo_msrv_verify
         run: cargo msrv verify --output-format json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,8 +38,10 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
-      - name: install_nasm
-        uses: ilammy/setup-nasm@v1
+      - name: setup_dav1d
+        uses: ./.github/actions/setup-dav1d
+        with:
+          setup-msvc: ${{ matrix.build != 'win-gnu-stable' }} # we don't prebuild libdav1d in the ci on this platform, which is required for the `avif-decoder` optional feature
 
       - name: fetch
         run: cargo fetch --verbose
@@ -57,7 +59,9 @@ jobs:
         run: cargo test --verbose --all --no-default-features
 
       - name: build_(all_features)
+        if: ${{ matrix.build != 'win-gnu-stable' }} # we don't prebuild libdav1d in the ci on this platform
         run: cargo build --verbose --all --all-features
 
       - name: test_all_(all_features)
+        if: ${{ matrix.build != 'win-gnu-stable' }} # we don't prebuild libdav1d in the ci on this platform
         run: cargo test --verbose --all --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - name: setup_dav1d
         uses: ./.github/actions/setup-dav1d
         with:
-          setup-msvc: ${{ matrix.build != 'win-gnu-stable' }} # we don't prebuild libdav1d in the ci on this platform, which is required for the `avif-decoder` optional feature
+          setup-msvc: ${{ matrix.build != 'win-gnu-stable' }}
 
       - name: fetch
         run: cargo fetch --verbose
@@ -59,9 +59,7 @@ jobs:
         run: cargo test --verbose --all --no-default-features
 
       - name: build_(all_features)
-        if: ${{ matrix.build != 'win-gnu-stable' }} # we don't prebuild libdav1d in the ci on this platform
         run: cargo build --verbose --all --all-features
 
       - name: test_all_(all_features)
-        if: ${{ matrix.build != 'win-gnu-stable' }} # we don't prebuild libdav1d in the ci on this platform
         run: cargo test --verbose --all --all-features

--- a/.justfiles/dav1d.just
+++ b/.justfiles/dav1d.just
@@ -1,0 +1,31 @@
+dav1d_version := "1.5.0"
+dav1d_repo := "https://code.videolan.org/videolan/dav1d.git"
+dav1d_src := justfile_directory() / "target" / "dav1d-src"
+dav1d_prefix := justfile_directory() / "target" / "dav1d"
+
+_install-dav1d-linux: _install-dav1d-unix
+_install-dav1d-macos: _install-dav1d-unix
+
+_install-dav1d-windows:
+    if (-not (Test-Path "{{ dav1d_src }}/.git")) { git clone --depth 1 -b {{ dav1d_version }} {{ dav1d_repo }} "{{ dav1d_src }}" } else { git -C "{{ dav1d_src }}" fetch --depth 1 origin {{ dav1d_version }}; git -C "{{ dav1d_src }}" checkout FETCH_HEAD }
+    if (Test-Path "{{ dav1d_src }}/build") { Remove-Item -Recurse -Force "{{ dav1d_src }}/build" }
+    $env:PATH = (($env:PATH -split ';') | Where-Object { $_ -notmatch '\\usr\\bin' }) -join ';'; meson setup -Ddefault_library=static --prefix "{{ dav1d_prefix }}" --libdir lib "{{ dav1d_src }}/build" "{{ dav1d_src }}"
+    $env:PATH = (($env:PATH -split ';') | Where-Object { $_ -notmatch '\\usr\\bin' }) -join ';'; ninja -C "{{ dav1d_src }}/build"
+    meson install -C "{{ dav1d_src }}/build"
+
+_install-dav1d-unix:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    src="{{ dav1d_src }}"
+    if [ ! -d "$src/.git" ]; then
+        git clone --depth 1 -b {{ dav1d_version }} {{ dav1d_repo }} "$src"
+    else
+        git -C "$src" fetch --depth 1 origin {{ dav1d_version }}
+        git -C "$src" checkout FETCH_HEAD
+    fi
+    rm -rf "$src/build"
+    meson setup -Ddefault_library=static --prefix "{{ dav1d_prefix }}" --libdir lib "$src/build" "$src"
+    ninja -C "$src/build"
+    meson install -C "$src/build"
+    printf 'dav1d installed at %s\n' "{{ dav1d_prefix }}"
+    printf 'export PKG_CONFIG_PATH="%s/lib/pkgconfig:$PKG_CONFIG_PATH"\n' "{{ dav1d_prefix }}"

--- a/.justfiles/dav1d_prerequisites.just
+++ b/.justfiles/dav1d_prerequisites.just
@@ -1,0 +1,10 @@
+_install-dav1d-prerequisites-linux:
+    sudo apt-get update
+    sudo apt-get install -y meson ninja-build nasm pkg-config
+
+_install-dav1d-prerequisites-macos:
+    brew install meson ninja nasm pkg-config
+
+_install-dav1d-prerequisites-windows:
+    python -m pip install --upgrade meson ninja
+    winget install --id NASM.NASM --exact --source winget --accept-source-agreements --accept-package-agreements

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,6 +25,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +184,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "av-data"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fca67ba5d317924c02180c576157afd54babe48a76ebc66ce6d34bb8ba08308e"
+dependencies = [
+ "byte-slice-cast",
+ "bytes",
+ "num-derive",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "av-scenechange"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,6 +258,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
+name = "bitreader"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886559b1e163d56c765bc3a985febb4eee8009f625244511d8ee3c432e08c066"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "bitstream-io"
 version = "4.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -273,16 +307,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "byte-slice-cast"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "byteorder-lite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "cc"
@@ -292,6 +344,16 @@ checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 dependencies = [
  "jobserver",
  "libc",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb693542bcafa528e198be0ebd9d3632ca5b7c93dbe7237460e199910835997c"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -437,6 +499,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "dav1d"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee89cb860616069c67520dcd66cacdb900b57c799f634a0eb6d91f6e2a82b61"
+dependencies = [
+ "av-data",
+ "bitflags 2.13.0",
+ "dav1d-sys",
+ "static_assertions",
+]
+
+[[package]]
+name = "dav1d-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3c91aea6668645415331133ed6f8ddf0e7f40160cd97a12d59e68716a58704b"
+dependencies = [
+ "libc",
+ "system-deps",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -491,6 +575,15 @@ dependencies = [
  "rayon-core",
  "smallvec",
  "zune-inflate",
+]
+
+[[package]]
+name = "fallible_collections"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a88c69768c0a15262df21899142bc6df9b9b823546d4b4b9a7bc2d6c448ec6fd"
+dependencies = [
+ "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -645,6 +738,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
@@ -689,10 +791,12 @@ dependencies = [
  "bytemuck",
  "byteorder-lite",
  "color_quant",
+ "dav1d",
  "exr",
  "gif",
  "image-webp",
  "moxcms",
+ "mp4parse",
  "num-traits",
  "png",
  "qoi",
@@ -766,7 +870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -927,6 +1031,20 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "mp4parse"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a35203d3c6ce92d5251c77520acb2e57108c88728695aa883f70023624c570"
+dependencies = [
+ "bitreader",
+ "byteorder",
+ "fallible_collections",
+ "log",
+ "num-traits",
+ "static_assertions",
 ]
 
 [[package]]
@@ -1188,6 +1306,12 @@ dependencies = [
  "pest",
  "sha2",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "png"
@@ -1524,6 +1648,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,6 +1775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +1820,25 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "system-deps"
+version = "7.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396a35feb67335377e0251fcbc1092fc85c484bd4e3a7a54319399da127796e7"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -1737,6 +1895,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.0+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "transpose"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,6 +1983,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -1931,6 +2134,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ yare = "3"
 [features]
 default = ["nasm"]
 nasm = ["sic_core/nasm"]
+avif-decoder = ["sic_core/avif-decoder"]
 
 output-test-images = []
 

--- a/crates/sic_core/Cargo.toml
+++ b/crates/sic_core/Cargo.toml
@@ -18,3 +18,4 @@ thiserror = { workspace = true }
 
 [features]
 nasm = ["image/nasm"]
+avif-decoder = ["image/avif-native"] # avif encoder (via ravif) is enabled by default, decoder requires native libdav1d

--- a/deny.toml
+++ b/deny.toml
@@ -19,6 +19,9 @@ allow = [
     "Zlib",
     "Unicode-3.0",
 ]
+exceptions = [
+    { name = "mp4parse", allow = ["MPL-2.0"] },
+]
 
 [[licenses.clarify]]
 name = "exr"

--- a/justfile
+++ b/justfile
@@ -1,7 +1,16 @@
-# determine the current Minimum Supported Rust Version for sic
-msrv:
-    cargo install cargo-msrv
-    cargo msrv find --output-format json --all-features --write-msrv
+import '.justfiles/dav1d.just'
+import '.justfiles/dav1d_prerequisites.just'
+
+set windows-shell := ["pwsh", "-NoLogo", "-Command"]
+
+default:
+    @just --choose
+
+install-dav1d-prerequisites:
+    just _install-dav1d-prerequisites-{{ os() }}
+
+install-dav1d:
+    just _install-dav1d-{{ os() }}
 
 # format all workspace packages
 fmt:
@@ -15,6 +24,11 @@ lint:
 test:
     cargo test --all-features --all
 
+# determine the current Minimum Supported Rust Version for sic
+msrv:
+    cargo install cargo-msrv
+    cargo msrv find --output-format json --all-features --write-msrv
+
 deny:
     cargo deny --all-features check
 
@@ -24,10 +38,6 @@ pre-commit:
     just lint
     just test
     just deny
-
-# package a release for the current platform
-pack-release:
-    cargo run -p pack-release
 
 publish-workspace new_version:
     cargo install cargo-publish-workspace


### PR DESCRIPTION
This adds the dav1d library which is a native decoder for av1f. It requires a bit more setup which is why I didn't enable it by default.

I decided against a build.rs file so everyone who installs from source isn't immediately thrown off by the complex build. Instead it's a cargo feature which is not enabled by default. For our own builds including the release, we will build it though.

Fingers crossed that it works though.

I used an LLM to help with the github workflow setup.

Assisted-by: claude-opus-4.8